### PR TITLE
fix: testing error related to svg caused by nextjs overwrite svg stud…

### DIFF
--- a/__mocks__/svgMock.js
+++ b/__mocks__/svgMock.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const svgMock = (...props) => {
+  const svg = React.createElement("svg", {
+    fill: "currentColor",
+    xmlns: "http://www.w3.org/2000/svg",
+    ...props[0],
+  });
+  return svg;
+};
+export default svgMock;

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,5 +38,17 @@ const customJestConfig = {
   },
 };
 
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig);
+const jestConfig = async () => {
+  // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+  const nextJestConfig = await createJestConfig(customJestConfig)();
+  return {
+    ...nextJestConfig,
+    moduleNameMapper: {
+      // Workaround to put our SVG stub first
+      "\\.svg$": "<rootDir>/__mocks__/svgMock.js",
+      ...nextJestConfig.moduleNameMapper,
+    },
+  };
+};
+
+module.exports = jestConfig;


### PR DESCRIPTION
This is the workaround way of fix for testing errors when mocking SVG files.

Basically, Nextjs overwrite the jest config with its own code so that the jest config is modified in the wrong order. This is a workaround to modified back the config with the prioritized SVG stud module and move it to the first of the mapper order with the created custom mock file.

As a result, all SVG testing will be normal with no errors.
