### PR TITLE
fix: transition of pricerbar overlaps with footer in wrong zindex order

### DIFF
--- a/src/components/EditorFooter/index.tsx
+++ b/src/components/EditorFooter/index.tsx
@@ -12,13 +12,14 @@ const EditorFooter = () => {
       justifyContent="space-between"
       alignItems="center"
       px={4}
-      w="100%"
+      w="calc(100vw - 98px)"
       bg="white"
-      boxShadow="xs"
+      boxShadow="dark-lg"
       lineHeight="34px"
-      zIndex={-1}
+      left="98px"
+      zIndex={1500}
     >
-      <Box ml="96px">
+      <Box>
         <IconButton
           aria-label="Revert edit"
           icon={<HiOutlineZoomOut />}


### PR DESCRIPTION
This is for fixing the transition of price bar overlaps with drawer in wrong zindex order.
![image](https://user-images.githubusercontent.com/12379895/169630903-f098b237-af7a-4947-a1d9-d944fc8656c0.png)
