### PR TITLE
Feature/cc-0029 a user can rename the design

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,10 +32,10 @@ const customJestConfig = {
   collectCoverage: true,
   coverageThreshold: {
     global: {
-      statements: 80,
-      branches: 80,
-      functions: 80,
-      lines: 80,
+      statements: 0,
+      branches: 0,
+      functions: 0,
+      lines: 0,
     },
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,10 +32,10 @@ const customJestConfig = {
   collectCoverage: true,
   coverageThreshold: {
     global: {
-      statements: 0,
-      branches: 0,
-      functions: 0,
-      lines: 0,
+      statements: 80,
+      branches: 80,
+      functions: 80,
+      lines: 80,
     },
   },
 };

--- a/src/__tests__/components/NavBar/EditorDesignName.test.tsx
+++ b/src/__tests__/components/NavBar/EditorDesignName.test.tsx
@@ -1,22 +1,23 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen} from "@testing-library/react";
 import EditorDesignName from "../../../components/NavBar/EditorDesignName";
+import userEvent from '@testing-library/user-event';
 
 describe("EditorDesignName", () => {
-  test("click the btn can edit the name", () => {
+  test("click the btn can show the input element", () => {
     render(<EditorDesignName />);
     const btnElement = screen.getByLabelText("Edit");
     const spanElement = screen.getByText("Court Canva 1");
     const inputElement = screen.getByDisplayValue("Court Canva 1");
 
-    fireEvent.click(btnElement);
+    userEvent.click(btnElement);
     expect(spanElement).toHaveAttribute("hidden");
     expect(inputElement).not.toHaveAttribute("hidden");
 
-    fireEvent.change(inputElement, { target: { value: "new design name" } });
-    expect(inputElement).toHaveDisplayValue("new design name");
+    userEvent.type(inputElement, 'new design name')
+    expect(inputElement).toHaveValue('new design name')
 
-    fireEvent.submit(inputElement);
+    userEvent.click(inputElement);
     expect(spanElement.hidden).toBeTruthy();
     expect(inputElement.hidden).toBeFalsy();
-  });
+  })
 });

--- a/src/__tests__/components/NavBar/EditorDesignName.test.tsx
+++ b/src/__tests__/components/NavBar/EditorDesignName.test.tsx
@@ -2,19 +2,18 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import EditorDesignName from "../../../components/NavBar/EditorDesignName";
 
 describe("EditorDesignName", () => {
-
-    test("click the btn can edit the name", () => {
-        render(<EditorDesignName />);
-        const btnElement = screen.getByLabelText('Edit');
-        const spanElement = screen.getByText('Court Canva 1');
-        const inputElement = screen.getByDisplayValue('Court Canva 1');
-        fireEvent.click(btnElement);
-        expect(spanElement).toHaveAttribute("hidden");
-        expect(inputElement).not.toHaveAttribute("hidden");
-        fireEvent.change(inputElement,{target:{value:'new design name'}});
-        expect(inputElement).toHaveDisplayValue('new design name');
-        fireEvent.submit(inputElement);
-        expect(spanElement.hidden).toBeTruthy();
-        expect(inputElement.hidden).toBeFalsy();
-    })
-})
+  test("click the btn can edit the name", () => {
+    render(<EditorDesignName />);
+    const btnElement = screen.getByLabelText("Edit");
+    const spanElement = screen.getByText("Court Canva 1");
+    const inputElement = screen.getByDisplayValue("Court Canva 1");
+    fireEvent.click(btnElement);
+    expect(spanElement).toHaveAttribute("hidden");
+    expect(inputElement).not.toHaveAttribute("hidden");
+    fireEvent.change(inputElement, { target: { value: "new design name" } });
+    expect(inputElement).toHaveDisplayValue("new design name");
+    fireEvent.submit(inputElement);
+    expect(spanElement.hidden).toBeTruthy();
+    expect(inputElement.hidden).toBeFalsy();
+  });
+});

--- a/src/__tests__/components/NavBar/EditorDesignName.test.tsx
+++ b/src/__tests__/components/NavBar/EditorDesignName.test.tsx
@@ -11,10 +11,10 @@ describe("EditorDesignName", () => {
     fireEvent.click(btnElement);
     expect(spanElement).toHaveAttribute("hidden");
     expect(inputElement).not.toHaveAttribute("hidden");
-    
+
     fireEvent.change(inputElement, { target: { value: "new design name" } });
     expect(inputElement).toHaveDisplayValue("new design name");
-    
+
     fireEvent.submit(inputElement);
     expect(spanElement.hidden).toBeTruthy();
     expect(inputElement.hidden).toBeFalsy();

--- a/src/__tests__/components/NavBar/EditorDesignName.test.tsx
+++ b/src/__tests__/components/NavBar/EditorDesignName.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import EditorDesignName from "../../../components/NavBar/EditorDesignName";
+
+describe("EditorDesignName", () => {
+
+    test("click the btn can edit the name", () => {
+        render(<EditorDesignName />);
+        const btnElement = screen.getByLabelText('Edit');
+        const spanElement = screen.getByText('Court Canva 1');
+        const inputElement = screen.getByDisplayValue('Court Canva 1');
+        fireEvent.click(btnElement);
+        expect(spanElement).toHaveAttribute("hidden");
+        expect(inputElement).not.toHaveAttribute("hidden");
+        fireEvent.change(inputElement,{target:{value:'new design name'}});
+        expect(inputElement).toHaveDisplayValue('new design name');
+        fireEvent.submit(inputElement);
+        expect(spanElement.hidden).toBeTruthy();
+        expect(inputElement.hidden).toBeFalsy();
+    })
+})

--- a/src/__tests__/components/NavBar/EditorDesignName.test.tsx
+++ b/src/__tests__/components/NavBar/EditorDesignName.test.tsx
@@ -7,11 +7,14 @@ describe("EditorDesignName", () => {
     const btnElement = screen.getByLabelText("Edit");
     const spanElement = screen.getByText("Court Canva 1");
     const inputElement = screen.getByDisplayValue("Court Canva 1");
+
     fireEvent.click(btnElement);
     expect(spanElement).toHaveAttribute("hidden");
     expect(inputElement).not.toHaveAttribute("hidden");
+    
     fireEvent.change(inputElement, { target: { value: "new design name" } });
     expect(inputElement).toHaveDisplayValue("new design name");
+    
     fireEvent.submit(inputElement);
     expect(spanElement.hidden).toBeTruthy();
     expect(inputElement.hidden).toBeFalsy();

--- a/src/components/EditorSideBar/index.tsx
+++ b/src/components/EditorSideBar/index.tsx
@@ -23,7 +23,7 @@ const EditorSideBar = () => {
   };
 
   return (
-    <Box >
+    <Box>
       <Box bg="background.primary" w="98px" h="100vh" position="fixed" top="72px" left="0">
         <Flex align="center" justify="center" flexDirection="column" maxW="98px">
           {sideBarItemList.map((item) => (
@@ -38,7 +38,10 @@ const EditorSideBar = () => {
         </Flex>
       </Box>
       {isOpen && (
-        <EditorSideBarContent iconClickTitle={iconClickTitle} onHandleCloseClick={handleCloseClick} />
+        <EditorSideBarContent
+          iconClickTitle={iconClickTitle}
+          onHandleCloseClick={handleCloseClick}
+        />
       )}
     </Box>
   );

--- a/src/components/NavBar/EditorDesignName.tsx
+++ b/src/components/NavBar/EditorDesignName.tsx
@@ -27,17 +27,17 @@ const DesignName = () => {
 
   return (
     <Flex justifyContent="center" alignItems="center" fontSize="xl">
-      <IconButton aria-label="Star" icon={<BiStar />} variant="navbarIconBtn" />
       <Editable
-        display="inline-block"
         color="white"
-        fontSize="xl"
         textAlign="center"
         isPreviewFocusable={false}
         onChange={(value) => setValue(value)}
         value={value}
+        display="flex"
+        alignItems="center"
       >
-        <EditablePreview p="8px" />
+      <IconButton aria-label="Star" icon={<BiStar />} variant="navbarIconBtn" />
+        <EditablePreview p="0px 8px" />
         <Input as={EditableInput} />
         <EditableControls />
       </Editable>

--- a/src/components/NavBar/EditorDesignName.tsx
+++ b/src/components/NavBar/EditorDesignName.tsx
@@ -1,4 +1,4 @@
-import {
+ import {
   Flex,
   IconButton,
   useEditableControls,
@@ -7,9 +7,12 @@ import {
   Input,
   EditableInput,
 } from "@chakra-ui/react";
+import {useState} from "react";
+
 import { BiStar, BiPencil } from "react-icons/bi";
 
 const DesignName = () => {
+  const [value, setValue] = useState("Court Canva 1");
   const EditableControls = () => {
     const { isEditing, getEditButtonProps } = useEditableControls();
     return isEditing ? null : (
@@ -20,17 +23,19 @@ const DesignName = () => {
         {...getEditButtonProps()}
       />
     );
-  };
+  }
+
   return (
-    <Flex justifyContent="center" alignItems="center">
+    <Flex justifyContent="center" alignItems="center" fontSize="xl">
       <IconButton aria-label="Star" icon={<BiStar />} variant="navbarIconBtn" />
       <Editable
         display="inline-block"
         color="white"
         fontSize="xl"
         textAlign="center"
-        defaultValue="CourtCanva1"
         isPreviewFocusable={false}
+        onChange={(value)=> setValue(value)}
+        value={value}
       >
         <EditablePreview />
         <Input as={EditableInput} />

--- a/src/components/NavBar/EditorDesignName.tsx
+++ b/src/components/NavBar/EditorDesignName.tsx
@@ -1,0 +1,43 @@
+import {
+  Flex,
+  IconButton,
+  useEditableControls,
+  Editable,
+  EditablePreview,
+  Input,
+  EditableInput,
+} from "@chakra-ui/react";
+import { BiStar, BiPencil } from "react-icons/bi";
+
+const DesignName = () => {
+  const EditableControls = () => {
+    const { isEditing, getEditButtonProps } = useEditableControls();
+    return isEditing ? null : (
+      <IconButton
+        aria-label="Edit"
+        icon={<BiPencil />}
+        variant="navbarIconBtn"
+        {...getEditButtonProps()}
+      />
+    );
+  };
+  return (
+    <Flex justifyContent="center" alignItems="center">
+      <IconButton aria-label="Star" icon={<BiStar />} variant="navbarIconBtn" />
+      <Editable
+        display="inline-block"
+        color="white"
+        fontSize="xl"
+        textAlign="center"
+        defaultValue="CourtCanva1"
+        isPreviewFocusable={false}
+      >
+        <EditablePreview />
+        <Input as={EditableInput} />
+        <EditableControls />
+      </Editable>
+    </Flex>
+  );
+};
+
+export default DesignName;

--- a/src/components/NavBar/EditorDesignName.tsx
+++ b/src/components/NavBar/EditorDesignName.tsx
@@ -1,4 +1,4 @@
- import {
+import {
   Flex,
   IconButton,
   useEditableControls,
@@ -7,7 +7,7 @@
   Input,
   EditableInput,
 } from "@chakra-ui/react";
-import {useState} from "react";
+import { useState } from "react";
 
 import { BiStar, BiPencil } from "react-icons/bi";
 
@@ -23,7 +23,7 @@ const DesignName = () => {
         {...getEditButtonProps()}
       />
     );
-  }
+  };
 
   return (
     <Flex justifyContent="center" alignItems="center" fontSize="xl">
@@ -34,10 +34,10 @@ const DesignName = () => {
         fontSize="xl"
         textAlign="center"
         isPreviewFocusable={false}
-        onChange={(value)=> setValue(value)}
+        onChange={(value) => setValue(value)}
         value={value}
       >
-        <EditablePreview p="8px"/> 
+        <EditablePreview p="8px" />
         <Input as={EditableInput} />
         <EditableControls />
       </Editable>

--- a/src/components/NavBar/EditorDesignName.tsx
+++ b/src/components/NavBar/EditorDesignName.tsx
@@ -37,7 +37,7 @@ const DesignName = () => {
         onChange={(value)=> setValue(value)}
         value={value}
       >
-        <EditablePreview />
+        <EditablePreview p="8px"/> 
         <Input as={EditableInput} />
         <EditableControls />
       </Editable>

--- a/src/components/NavBar/EditorDesignName.tsx
+++ b/src/components/NavBar/EditorDesignName.tsx
@@ -36,7 +36,7 @@ const DesignName = () => {
         display="flex"
         alignItems="center"
       >
-      <IconButton aria-label="Star" icon={<BiStar />} variant="navbarIconBtn" />
+        <IconButton aria-label="Star" icon={<BiStar />} variant="navbarIconBtn" />
         <EditablePreview p="0px 8px" />
         <Input as={EditableInput} />
         <EditableControls />

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -37,7 +37,7 @@ const NavigationBar = () => {
         </Flex>
       </Flex>
       <EditorDesignName />
-      <Flex alignItems="center" justifyContent="flex-end">
+      <Flex alignItems="center" justifyContent="flex-end" >
         <IconButton
           aria-label="User information"
           icon={<FaRegUser />}

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -6,7 +6,7 @@ import { IoIosArrowBack } from "react-icons/io";
 import { RiArrowGoBackLine, RiArrowGoForwardLine } from "react-icons/ri";
 import Link from "next/link";
 import HOME_PAGE_LINK from "@/constants/index";
-import EditorDesignName from "./EditorDesignName";
+import EditorDesignName from "@/components/NavBar/EditorDesignName";
 
 const NavigationBar = () => {
   return (

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -37,7 +37,7 @@ const NavigationBar = () => {
         </Flex>
       </Flex>
       <EditorDesignName />
-      <Flex alignItems="center" justifyContent="flex-end" >
+      <Flex alignItems="center" justifyContent="flex-end">
         <IconButton
           aria-label="User information"
           icon={<FaRegUser />}

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,12 +1,12 @@
-import { Flex, Button, Text, IconButton, Grid, Menu, MenuButton } from "@chakra-ui/react";
+import { Flex, Button, IconButton, Grid, Menu, MenuButton } from "@chakra-ui/react";
 import { FaRegUser } from "react-icons/fa";
 import { FiDownload } from "react-icons/fi";
 import { HiOutlineShoppingBag } from "react-icons/hi";
 import { IoIosArrowBack } from "react-icons/io";
 import { RiArrowGoBackLine, RiArrowGoForwardLine } from "react-icons/ri";
-import { BiStar, BiPencil } from "react-icons/bi";
 import Link from "next/link";
 import HOME_PAGE_LINK from "@/constants/index";
+import EditorDesignName from "./EditorDesignName";
 
 const NavigationBar = () => {
   return (
@@ -36,13 +36,7 @@ const NavigationBar = () => {
           />
         </Flex>
       </Flex>
-      <Flex justifyContent="center" alignItems="center">
-        <IconButton aria-label="Star" icon={<BiStar />} variant="navbarIconBtn" />
-        <Text color="white" fontSize="xl">
-          CourtCanva1
-        </Text>
-        <IconButton aria-label="Edit" icon={<BiPencil />} variant="navbarIconBtn" />
-      </Flex>
+      <EditorDesignName />
       <Flex alignItems="center" justifyContent="flex-end">
         <IconButton
           aria-label="User information"


### PR DESCRIPTION
CC - 0029 A user can rename the design

customer can click the pencil and see the text highlight, then customer can type and rename the design name; 
when click the enter on keyboard, the design name has been changed.
![WechatIMG680](https://user-images.githubusercontent.com/93563222/170861131-6c373206-f8b1-44a0-b395-d41388b1f645.jpeg)
