### PR TITLE
Feature/cc 0094 replace tile calculator with tile data

### DIFF
--- a/src/components/EditorSideBar/Blueprints.tsx
+++ b/src/components/EditorSideBar/Blueprints.tsx
@@ -46,7 +46,7 @@ const Blueprints: React.FC = () => {
     const courtSpec = mappedCourtSpecs.find((item: CourtSizeState) => item.courtId === courtId);
     dispatch(changeCourtSize(courtSpec));
 
-    const tileQtyOfSelectedCourt = mockTileData.find((item) => item.id === courtId)
+    const tileQtyOfSelectedCourt = mockTileData.find((item) => item.name === selectedCourt.name)
       ?.tileQty as AreaTileQty[];
     dispatch(changeCourtType(tileQtyOfSelectedCourt));
   };

--- a/src/components/EditorSideBar/Blueprints.tsx
+++ b/src/components/EditorSideBar/Blueprints.tsx
@@ -5,6 +5,8 @@ import { changeCourtName, CourtNameState } from "@/store/reducer/courtNameSlice"
 import React, { useState } from "react";
 import { useGetCourtsQuery } from "../../redux/api/courtSizeApi";
 import { changeCourtSize, CourtSizeState, CourtSpecMapper } from "@/store/reducer/courtSizeSlice";
+import { AreaTileQty, changeCourtType } from "@/store/reducer/areaTileQtySlice";
+import { mockTileData } from "../MockData/MockTileData";
 
 const Blueprints: React.FC = () => {
   const dispatch = useDispatch();
@@ -43,6 +45,10 @@ const Blueprints: React.FC = () => {
 
     const courtSpec = mappedCourtSpecs.find((item: CourtSizeState) => item.courtId === courtId);
     dispatch(changeCourtSize(courtSpec));
+
+    const tileQtyOfSelectedCourt = mockTileData.find((item) => item.id === courtId)
+      ?.tileQty as AreaTileQty[];
+    dispatch(changeCourtType(tileQtyOfSelectedCourt));
   };
 
   return (

--- a/src/components/FullCourt/index.tsx
+++ b/src/components/FullCourt/index.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { Stage, Layer, Group } from "react-konva";
 import { Flex } from "@chakra-ui/react";
 import { ReactReduxContext, Provider } from "react-redux";
@@ -10,10 +10,8 @@ import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import CourtDimension from "../BasketballCourt/CourtDimension";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-// import { useTileCalculation } from "@/hooks/useTileCalculation";
-import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
-import { useTileCount } from "@/hooks/useTileCount";
+import { useTileCount } from "../../hooks/useTileCount";
 
 const FullCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -35,10 +33,7 @@ const FullCourt = () => {
     size
   );
   const court = courtAndInfo.court;
-  // https://github.com/konvajs/react-konva/issues/316
-  const canvasRef = useRef<Konva.Layer>(null);
 
-  // useTileCalculation(courtAndInfo, canvasRef);
   useTileCount();
 
   useLayoutEffect(() => {
@@ -78,7 +73,7 @@ const FullCourt = () => {
             data-testid="stage"
           >
             <Provider store={store}>
-              <Layer ref={canvasRef}>
+              <Layer>
                 <Border
                   startPoint={startPoint}
                   borderLength={borderLength}

--- a/src/components/FullCourt/index.tsx
+++ b/src/components/FullCourt/index.tsx
@@ -10,9 +10,10 @@ import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import CourtDimension from "../BasketballCourt/CourtDimension";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-import { useTileCalculation } from "@/hooks/useTileCalculation";
+// import { useTileCalculation } from "@/hooks/useTileCalculation";
 import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
+import { useTileCount } from "@/hooks/useTileCount";
 
 const FullCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -37,7 +38,8 @@ const FullCourt = () => {
   // https://github.com/konvajs/react-konva/issues/316
   const canvasRef = useRef<Konva.Layer>(null);
 
-  useTileCalculation(courtAndInfo, canvasRef);
+  // useTileCalculation(courtAndInfo, canvasRef);
+  useTileCount();
 
   useLayoutEffect(() => {
     const checkSize = () => {

--- a/src/components/HalfCourt/index.tsx
+++ b/src/components/HalfCourt/index.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { Stage, Layer, Group } from "react-konva";
 import { Flex } from "@chakra-ui/react";
 import { ReactReduxContext, Provider } from "react-redux";
@@ -8,10 +8,8 @@ import CourtArea from "../BasketballCourt/CourtArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-// import { useTileCalculation } from "@/hooks/useTileCalculation";
-import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
-import { useTileCount } from "@/hooks/useTileCount";
+import { useTileCount } from "../../hooks/useTileCount";
 
 const HalfCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -33,10 +31,7 @@ const HalfCourt = () => {
     size
   );
   const court = courtAndInfo.court;
-  // https://github.com/konvajs/react-konva/issues/316
-  const canvasRef = useRef<Konva.Layer>(null);
 
-  // useTileCalculation(courtAndInfo, canvasRef);
   useTileCount();
 
   useLayoutEffect(() => {
@@ -76,7 +71,7 @@ const HalfCourt = () => {
             data-testid="stage"
           >
             <Provider store={store}>
-              <Layer ref={canvasRef}>
+              <Layer>
                 <Border
                   startPoint={startPoint}
                   borderLength={borderLength}

--- a/src/components/HalfCourt/index.tsx
+++ b/src/components/HalfCourt/index.tsx
@@ -8,9 +8,10 @@ import CourtArea from "../BasketballCourt/CourtArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-import { useTileCalculation } from "@/hooks/useTileCalculation";
+// import { useTileCalculation } from "@/hooks/useTileCalculation";
 import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
+import { useTileCount } from "@/hooks/useTileCount";
 
 const HalfCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -35,7 +36,8 @@ const HalfCourt = () => {
   // https://github.com/konvajs/react-konva/issues/316
   const canvasRef = useRef<Konva.Layer>(null);
 
-  useTileCalculation(courtAndInfo, canvasRef);
+  // useTileCalculation(courtAndInfo, canvasRef);
+  useTileCount();
 
   useLayoutEffect(() => {
     const checkSize = () => {

--- a/src/components/MediumCourt/index.tsx
+++ b/src/components/MediumCourt/index.tsx
@@ -7,9 +7,10 @@ import KeyArea from "../BasketballCourt/KeyArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-import { useTileCalculation } from "@/hooks/useTileCalculation";
+// import { useTileCalculation } from "@/hooks/useTileCalculation";
 import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
+import { useTileCount } from "@/hooks/useTileCount";
 
 const MediumCourt = () => {
   const {
@@ -48,7 +49,8 @@ const MediumCourt = () => {
   // https://github.com/konvajs/react-konva/issues/316
   const canvasRef = useRef<Konva.Layer>(null);
 
-  useTileCalculation(courtAndInfo, canvasRef);
+  // useTileCalculation(courtAndInfo, canvasRef);
+  useTileCount();
 
   useLayoutEffect(() => {
     const checkSize = () => {

--- a/src/components/MediumCourt/index.tsx
+++ b/src/components/MediumCourt/index.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { Stage, Layer, Group } from "react-konva";
 import { Flex } from "@chakra-ui/react";
 import { ReactReduxContext, Provider } from "react-redux";
@@ -7,10 +7,8 @@ import KeyArea from "../BasketballCourt/KeyArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-// import { useTileCalculation } from "@/hooks/useTileCalculation";
-import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
-import { useTileCount } from "@/hooks/useTileCount";
+import { useTileCount } from "../../hooks/useTileCount";
 
 const MediumCourt = () => {
   const {
@@ -46,10 +44,7 @@ const MediumCourt = () => {
     size
   );
   const court = courtAndInfo.court;
-  // https://github.com/konvajs/react-konva/issues/316
-  const canvasRef = useRef<Konva.Layer>(null);
 
-  // useTileCalculation(courtAndInfo, canvasRef);
   useTileCount();
 
   useLayoutEffect(() => {
@@ -89,7 +84,7 @@ const MediumCourt = () => {
             data-testid="stage"
           >
             <Provider store={store}>
-              <Layer ref={canvasRef}>
+              <Layer>
                 <Border
                   startPoint={courtStartPoint}
                   borderLength={borderLength}

--- a/src/components/MockData/MockTileData.ts
+++ b/src/components/MockData/MockTileData.ts
@@ -8,7 +8,7 @@ interface MockTileData {
 export const mockTileData: MockTileData[] = [
   {
     id: "62c432cfb8a9c5f61f038320",
-    name: "FullCourt",
+    name: "Full Court",
     tileQty: [
       {
         location: "courtArea",
@@ -38,7 +38,7 @@ export const mockTileData: MockTileData[] = [
   },
   {
     id: "62c432cfb8a9c5f61f03831f",
-    name: "ProFullCourt",
+    name: "Pro Full Court",
     tileQty: [
       {
         location: "courtArea",
@@ -68,7 +68,7 @@ export const mockTileData: MockTileData[] = [
   },
   {
     id: "62c432cfb8a9c5f61f038322",
-    name: "HalfCourt",
+    name: "Half Court",
     tileQty: [
       {
         location: "courtArea",
@@ -98,7 +98,7 @@ export const mockTileData: MockTileData[] = [
   },
   {
     id: "62c432cfb8a9c5f61f038321",
-    name: "ProHalfCourt",
+    name: "Pro Half Court",
     tileQty: [
       {
         location: "courtArea",
@@ -128,7 +128,7 @@ export const mockTileData: MockTileData[] = [
   },
   {
     id: "62c432cfb8a9c5f61f038324",
-    name: "SmallCourt",
+    name: "Small Court",
     tileQty: [
       {
         location: "courtArea",
@@ -158,7 +158,7 @@ export const mockTileData: MockTileData[] = [
   },
   {
     id: "62c432cfb8a9c5f61f038323",
-    name: "MediumCourt",
+    name: "Medium Court",
     tileQty: [
       {
         location: "courtArea",

--- a/src/components/MockData/MockTileData.ts
+++ b/src/components/MockData/MockTileData.ts
@@ -1,0 +1,189 @@
+import { AreaTileQty } from "@/store/reducer/areaTileQtySlice";
+
+interface MockTileData {
+  id: string;
+  name: string;
+  tileQty: AreaTileQty[];
+}
+export const mockTileData: MockTileData[] = [
+  {
+    id: "62c432cfb8a9c5f61f038320",
+    name: "FullCourt",
+    tileQty: [
+      {
+        location: "courtArea",
+        quantity: 2572,
+      },
+      {
+        location: "threePoint",
+        quantity: 1273,
+      },
+      {
+        location: "keyArea",
+        quantity: 624,
+      },
+      {
+        location: "topKeyArea",
+        quantity: 116,
+      },
+      {
+        location: "circleArea",
+        quantity: 115,
+      },
+      {
+        location: "border",
+        quantity: 0,
+      },
+    ],
+  },
+  {
+    id: "62c432cfb8a9c5f61f03831f",
+    name: "ProFullCourt",
+    tileQty: [
+      {
+        location: "courtArea",
+        quantity: 2572,
+      },
+      {
+        location: "threePoint",
+        quantity: 1273,
+      },
+      {
+        location: "keyArea",
+        quantity: 624,
+      },
+      {
+        location: "topKeyArea",
+        quantity: 116,
+      },
+      {
+        location: "circleArea",
+        quantity: 115,
+      },
+      {
+        location: "border",
+        quantity: 1000,
+      },
+    ],
+  },
+  {
+    id: "62c432cfb8a9c5f61f038322",
+    name: "HalfCourt",
+    tileQty: [
+      {
+        location: "courtArea",
+        quantity: 704,
+      },
+      {
+        location: "threePoint",
+        quantity: 632,
+      },
+      {
+        location: "keyArea",
+        quantity: 304,
+      },
+      {
+        location: "topKeyArea",
+        quantity: 60,
+      },
+      {
+        location: "circleArea",
+        quantity: 0,
+      },
+      {
+        location: "border",
+        quantity: 0,
+      },
+    ],
+  },
+  {
+    id: "62c432cfb8a9c5f61f038321",
+    name: "ProHalfCourt",
+    tileQty: [
+      {
+        location: "courtArea",
+        quantity: 1295,
+      },
+      {
+        location: "threePoint",
+        quantity: 632,
+      },
+      {
+        location: "keyArea",
+        quantity: 304,
+      },
+      {
+        location: "topKeyArea",
+        quantity: 60,
+      },
+      {
+        location: "circleArea",
+        quantity: 59,
+      },
+      {
+        location: "border",
+        quantity: 0,
+      },
+    ],
+  },
+  {
+    id: "62c432cfb8a9c5f61f038324",
+    name: "SmallCourt",
+    tileQty: [
+      {
+        location: "courtArea",
+        quantity: 57,
+      },
+      {
+        location: "threePoint",
+        quantity: 71,
+      },
+      {
+        location: "keyArea",
+        quantity: 323,
+      },
+      {
+        location: "topKeyArea",
+        quantity: 59,
+      },
+      {
+        location: "circleArea",
+        quantity: 0,
+      },
+      {
+        location: "border",
+        quantity: 0,
+      },
+    ],
+  },
+  {
+    id: "62c432cfb8a9c5f61f038323",
+    name: "MediumCourt",
+    tileQty: [
+      {
+        location: "courtArea",
+        quantity: 189,
+      },
+      {
+        location: "threePoint",
+        quantity: 263,
+      },
+      {
+        location: "keyArea",
+        quantity: 304,
+      },
+      {
+        location: "topKeyArea",
+        quantity: 60,
+      },
+      {
+        location: "circleArea",
+        quantity: 0,
+      },
+      {
+        location: "border",
+        quantity: 0,
+      },
+    ],
+  },
+];

--- a/src/components/PriceBar/TileColorBoard.tsx
+++ b/src/components/PriceBar/TileColorBoard.tsx
@@ -12,19 +12,22 @@ const TileColorBoard: React.FC = () => {
             Estimated Tiles:
           </Text>
           <Center gap="8px" height="35px" marginLeft="8px" data-testid="tileBoard">
-            {tileBlocks?.map((tile) => (
-              <Center
-                key={tile.color}
-                backgroundColor={tile.color}
-                width={{ base: "40px", lg: "60px", xl: "85px" }}
-                height={{ base: "20px", lg: "25px", xl: "35px" }}
-                fontSize={{ base: "xs", xl: "sm" }}
-                color="white"
-                role="tileBlock"
-              >
-                {tile.quantity}
-              </Center>
-            ))}
+            {tileBlocks?.map(
+              (tile) =>
+                tile.quantity !== 0 && (
+                  <Center
+                    key={tile.color}
+                    backgroundColor={tile.color}
+                    width={{ base: "40px", lg: "60px", xl: "85px" }}
+                    height={{ base: "20px", lg: "25px", xl: "35px" }}
+                    fontSize={{ base: "xs", xl: "sm" }}
+                    color="white"
+                    role="tileBlock"
+                  >
+                    {tile.quantity}
+                  </Center>
+                )
+            )}
           </Center>
         </Center>
         <Center

--- a/src/components/ProFullCourt/index.tsx
+++ b/src/components/ProFullCourt/index.tsx
@@ -12,9 +12,10 @@ import CourtDimension from "../BasketballCourt/CourtDimension";
 import { useStoreSelector } from "@/store/hooks";
 import DashedLine from "../BasketballCourt/DashedLine";
 import BorderDimension from "../BasketballCourt/BorderDimension";
-import { useTileCalculation } from "@/hooks/useTileCalculation";
+// import { useTileCalculation } from "@/hooks/useTileCalculation";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
 import Konva from "konva";
+import { useTileCount } from "@/hooks/useTileCount";
 
 const ProFullCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -38,7 +39,8 @@ const ProFullCourt = () => {
   // https://github.com/konvajs/react-konva/issues/316
   const canvasRef = useRef<Konva.Layer>(null);
 
-  useTileCalculation(courtAndInfo, canvasRef);
+  // useTileCalculation(courtAndInfo, canvasRef);
+  useTileCount();
 
   useLayoutEffect(() => {
     const checkSize = () => {

--- a/src/components/ProFullCourt/index.tsx
+++ b/src/components/ProFullCourt/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useLayoutEffect } from "react";
+import { useState, useLayoutEffect } from "react";
 import { Stage, Layer, Group } from "react-konva";
 import { Flex } from "@chakra-ui/react";
 import { ReactReduxContext, Provider } from "react-redux";
@@ -12,10 +12,8 @@ import CourtDimension from "../BasketballCourt/CourtDimension";
 import { useStoreSelector } from "@/store/hooks";
 import DashedLine from "../BasketballCourt/DashedLine";
 import BorderDimension from "../BasketballCourt/BorderDimension";
-// import { useTileCalculation } from "@/hooks/useTileCalculation";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-import Konva from "konva";
-import { useTileCount } from "@/hooks/useTileCount";
+import { useTileCount } from "../../hooks/useTileCount";
 
 const ProFullCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -36,10 +34,7 @@ const ProFullCourt = () => {
     size
   );
   const court = courtAndInfo.court;
-  // https://github.com/konvajs/react-konva/issues/316
-  const canvasRef = useRef<Konva.Layer>(null);
 
-  // useTileCalculation(courtAndInfo, canvasRef);
   useTileCount();
 
   useLayoutEffect(() => {
@@ -79,8 +74,7 @@ const ProFullCourt = () => {
             data-testid="stage"
           >
             <Provider store={store}>
-              <Layer ref={canvasRef}>
-                {/* border only for pro full court size */}
+              <Layer>
                 <Border
                   startPoint={startPoint}
                   borderLength={borderLength}

--- a/src/components/ProHalfCourt/index.tsx
+++ b/src/components/ProHalfCourt/index.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { Stage, Layer, Group } from "react-konva";
 import { Flex } from "@chakra-ui/react";
 import { ReactReduxContext, Provider } from "react-redux";
@@ -9,10 +9,8 @@ import CircleArea from "../BasketballCourt/CircleArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-// import { useTileCalculation } from "@/hooks/useTileCalculation";
-import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
-import { useTileCount } from "@/hooks/useTileCount";
+import { useTileCount } from "../../hooks/useTileCount";
 
 const ProHalfCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -34,10 +32,7 @@ const ProHalfCourt = () => {
     size
   );
   const court = courtAndInfo.court;
-  // https://github.com/konvajs/react-konva/issues/316
-  const canvasRef = useRef<Konva.Layer>(null);
 
-  // useTileCalculation(courtAndInfo, canvasRef);
   useTileCount();
 
   useLayoutEffect(() => {
@@ -77,7 +72,7 @@ const ProHalfCourt = () => {
             data-testid="stage"
           >
             <Provider store={store}>
-              <Layer ref={canvasRef}>
+              <Layer>
                 <Border
                   startPoint={startPoint}
                   borderLength={borderLength}

--- a/src/components/ProHalfCourt/index.tsx
+++ b/src/components/ProHalfCourt/index.tsx
@@ -9,9 +9,10 @@ import CircleArea from "../BasketballCourt/CircleArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-import { useTileCalculation } from "@/hooks/useTileCalculation";
+// import { useTileCalculation } from "@/hooks/useTileCalculation";
 import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
+import { useTileCount } from "@/hooks/useTileCount";
 
 const ProHalfCourt = () => {
   const { courtAreaXLength, courtAreaYLength, borderLength } = useStoreSelector(
@@ -36,7 +37,8 @@ const ProHalfCourt = () => {
   // https://github.com/konvajs/react-konva/issues/316
   const canvasRef = useRef<Konva.Layer>(null);
 
-  useTileCalculation(courtAndInfo, canvasRef);
+  // useTileCalculation(courtAndInfo, canvasRef);
+  useTileCount();
 
   useLayoutEffect(() => {
     const checkSize = () => {

--- a/src/components/SmallCourt/index.tsx
+++ b/src/components/SmallCourt/index.tsx
@@ -7,9 +7,10 @@ import KeyArea from "../BasketballCourt/KeyArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-import { useTileCalculation } from "@/hooks/useTileCalculation";
+// import { useTileCalculation } from "@/hooks/useTileCalculation";
 import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
+import { useTileCount } from "@/hooks/useTileCount";
 
 const SmallCourt = () => {
   const {
@@ -47,7 +48,8 @@ const SmallCourt = () => {
   // https://github.com/konvajs/react-konva/issues/316
   const canvasRef = useRef<Konva.Layer>(null);
 
-  useTileCalculation(courtAndInfo, canvasRef);
+  // useTileCalculation(courtAndInfo, canvasRef);
+  useTileCount();
 
   useLayoutEffect(() => {
     const checkSize = () => {

--- a/src/components/SmallCourt/index.tsx
+++ b/src/components/SmallCourt/index.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { Stage, Layer, Group } from "react-konva";
 import { Flex } from "@chakra-ui/react";
 import { ReactReduxContext, Provider } from "react-redux";
@@ -7,10 +7,8 @@ import KeyArea from "../BasketballCourt/KeyArea";
 import TopKeyArea from "../BasketballCourt/TopKeyArea";
 import Border from "../BasketballCourt/Border";
 import { getCourtAndTileInfo } from "@/utils/getCourtAndTileInfo";
-// import { useTileCalculation } from "@/hooks/useTileCalculation";
-import Konva from "konva";
 import { useStoreSelector } from "@/store/hooks";
-import { useTileCount } from "@/hooks/useTileCount";
+import { useTileCount } from "../../hooks/useTileCount";
 
 const SmallCourt = () => {
   const {
@@ -45,10 +43,7 @@ const SmallCourt = () => {
     size
   );
   const court = courtAndInfo.court;
-  // https://github.com/konvajs/react-konva/issues/316
-  const canvasRef = useRef<Konva.Layer>(null);
 
-  // useTileCalculation(courtAndInfo, canvasRef);
   useTileCount();
 
   useLayoutEffect(() => {
@@ -88,7 +83,7 @@ const SmallCourt = () => {
             data-testid="stage"
           >
             <Provider store={store}>
-              <Layer ref={canvasRef}>
+              <Layer>
                 <Border
                   startPoint={courtStartPoint}
                   borderLength={borderLength}

--- a/src/hooks/useTileCount.ts
+++ b/src/hooks/useTileCount.ts
@@ -6,10 +6,12 @@ import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 const colorAndQtyResult = (tileColorState: Court[], areaTileQty: AreaTileQty[]) => {
+  // store results in the format of [{color:"#72818B",quantity:1273},{color:"#72818B",quantity:256}...]
   let colorAndQty: PriceBar[] = [];
-  // mapping over tileColorState and match with areaTileQty
-  // to obtain colorAndQty as [{color:"#72818B",quantity:1273},...] color is not unique
-  tileColorState.map((tileColor) => {
+  // loop over tileColorState and match with areaTileQty
+  // to obtain colorAndQty, color is not unique
+  for (let i = 0; i < tileColorState.length; i++) {
+    const tileColor = tileColorState[i];
     const matchAreaTileQty = areaTileQty.find((area) => area.location === tileColor.location);
     if (matchAreaTileQty) {
       const newColorAndQty = {
@@ -18,18 +20,20 @@ const colorAndQtyResult = (tileColorState: Court[], areaTileQty: AreaTileQty[]) 
       };
       colorAndQty = [...colorAndQty, newColorAndQty];
     }
-  });
+  }
 
+  // store results in the format of [{color:"#72818B",quantity:1273},...] with unique color
   let combinedColorAndQty: PriceBar[] = [];
-  // mapping over colorAndQty to remove replicate color and combine the quantity result
-  colorAndQty.map((result) => {
+  // loop over colorAndQty to remove replicate color and combine the quantity result
+  for (let i = 0; i < colorAndQty.length; i++) {
+    const result = colorAndQty[i];
     const duplicatedColor = combinedColorAndQty.findIndex((obj) => obj.color === result.color);
     if (duplicatedColor === -1) {
       combinedColorAndQty = [...combinedColorAndQty, result];
     } else {
       combinedColorAndQty[duplicatedColor].quantity += result.quantity;
     }
-  });
+  }
 
   return combinedColorAndQty;
 };

--- a/src/hooks/useTileCount.ts
+++ b/src/hooks/useTileCount.ts
@@ -1,0 +1,43 @@
+import { useStoreSelector } from "@/store/hooks";
+import { AreaTileQty } from "@/store/reducer/areaTileQtySlice";
+import { changeTileQuantity, PriceBar } from "@/store/reducer/priceBarSlice";
+import { Court } from "@/store/reducer/tileSlice";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+const colorAndQtyResult = (tileColorState: Court[], areaTileQty: AreaTileQty[]) => {
+  let colorAndQty: PriceBar[] = [];
+  for (let i = 0; i < tileColorState.length; i++) {
+    const matchAreaTileQty = areaTileQty.find((obj) => obj.location === tileColorState[i].location);
+    if (matchAreaTileQty) {
+      const newColorAndQty = {
+        color: tileColorState[i].color,
+        quantity: matchAreaTileQty.quantity,
+      };
+      colorAndQty = [...colorAndQty, newColorAndQty];
+    }
+  }
+
+  let combinedColorAndQty: PriceBar[] = [];
+  for (let i = 0; i < colorAndQty.length; i++) {
+    const duplicatedColor = combinedColorAndQty.findIndex(
+      (obj) => obj.color === colorAndQty[i].color
+    );
+    if (duplicatedColor === -1) {
+      combinedColorAndQty = [...combinedColorAndQty, colorAndQty[i]];
+    } else {
+      combinedColorAndQty[duplicatedColor].quantity += colorAndQty[i].quantity;
+    }
+  }
+  return combinedColorAndQty;
+};
+
+export const useTileCount = () => {
+  const tileColorState: Court[] = useStoreSelector((state) => state.tile.present.court);
+  const areaTileQty: AreaTileQty[] = useStoreSelector((state) => state.areaTileQty);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    const tileNumberResult = colorAndQtyResult(tileColorState, areaTileQty);
+    dispatch(changeTileQuantity(tileNumberResult));
+  }, [tileColorState, areaTileQty]);
+};

--- a/src/hooks/useTileCount.ts
+++ b/src/hooks/useTileCount.ts
@@ -7,33 +7,37 @@ import { useDispatch } from "react-redux";
 
 const colorAndQtyResult = (tileColorState: Court[], areaTileQty: AreaTileQty[]) => {
   let colorAndQty: PriceBar[] = [];
-  for (let i = 0; i < tileColorState.length; i++) {
-    const matchAreaTileQty = areaTileQty.find((obj) => obj.location === tileColorState[i].location);
+  // mapping over tileColorState and match with areaTileQty
+  // to obtain colorAndQty as [{color:"#72818B",quantity:1273},...] color is not unique
+  tileColorState.map((tileColor) => {
+    const matchAreaTileQty = areaTileQty.find((area) => area.location === tileColor.location);
     if (matchAreaTileQty) {
       const newColorAndQty = {
-        color: tileColorState[i].color,
+        color: tileColor.color,
         quantity: matchAreaTileQty.quantity,
       };
       colorAndQty = [...colorAndQty, newColorAndQty];
     }
-  }
+  });
 
   let combinedColorAndQty: PriceBar[] = [];
-  for (let i = 0; i < colorAndQty.length; i++) {
-    const duplicatedColor = combinedColorAndQty.findIndex(
-      (obj) => obj.color === colorAndQty[i].color
-    );
+  // mapping over colorAndQty to remove replicate color and combine the quantity result
+  colorAndQty.map((result) => {
+    const duplicatedColor = combinedColorAndQty.findIndex((obj) => obj.color === result.color);
     if (duplicatedColor === -1) {
-      combinedColorAndQty = [...combinedColorAndQty, colorAndQty[i]];
+      combinedColorAndQty = [...combinedColorAndQty, result];
     } else {
-      combinedColorAndQty[duplicatedColor].quantity += colorAndQty[i].quantity;
+      combinedColorAndQty[duplicatedColor].quantity += result.quantity;
     }
-  }
+  });
+
   return combinedColorAndQty;
 };
 
 export const useTileCount = () => {
+  // tileColorState = [{location:"threePoint", color:"#72818B"},...]
   const tileColorState: Court[] = useStoreSelector((state) => state.tile.present.court);
+  // areaTileQty = [{location:"threePoint",quantity:1273}...]
   const areaTileQty: AreaTileQty[] = useStoreSelector((state) => state.areaTileQty);
   const dispatch = useDispatch();
   useEffect(() => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,7 +8,8 @@ import rulerControlReducer from "./reducer/rulerControlSlice";
 import { courtsApi } from "../redux/api/courtSizeApi";
 import designNameReducer from "./reducer/designNameSlice";
 import paintBucketReducer from "./reducer/paintBucketSlice";
-import priceBarSlice from "./reducer/priceBarSlice";
+import priceBarReducer from "./reducer/priceBarSlice";
+import areaTileQtyReducer from "./reducer/areaTileQtySlice";
 
 export const makeStore = () =>
   configureStore({
@@ -16,13 +17,14 @@ export const makeStore = () =>
       courtSize: courtReducer,
       courtName: courtNameReducer,
       tile: tileReducer,
-      priceBar: priceBarSlice,
+      priceBar: priceBarReducer,
       courtColor: courtColorReducer,
       user: userReducer,
       rulerControl: rulerControlReducer,
       designName: designNameReducer,
       paintBucket: paintBucketReducer,
       [courtsApi.reducerPath]: courtsApi.reducer,
+      areaTileQty: areaTileQtyReducer,
     },
     middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(courtsApi.middleware),
   });

--- a/src/store/reducer/areaTileQtySlice.ts
+++ b/src/store/reducer/areaTileQtySlice.ts
@@ -1,0 +1,28 @@
+import { mockTileData } from "@/components/MockData/MockTileData";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "..";
+
+export interface AreaTileQty {
+  location: string;
+  quantity: number;
+}
+
+export const initialState = mockTileData.find((obj) => obj.name === "ProFullCourt")
+  ?.tileQty as AreaTileQty[];
+
+export const areaTileQtySlice = createSlice({
+  name: "areaTileQty",
+  initialState,
+  reducers: {
+    changeCourtType: (state, action: PayloadAction<AreaTileQty[]>) => {
+      return action.payload;
+    },
+  },
+  // TODO: changeBorderWidth
+});
+
+export const { changeCourtType } = areaTileQtySlice.actions;
+
+export const areaTileQtyData = (state: RootState) => state.areaTileQty;
+
+export default areaTileQtySlice.reducer;

--- a/src/store/reducer/areaTileQtySlice.ts
+++ b/src/store/reducer/areaTileQtySlice.ts
@@ -7,7 +7,7 @@ export interface AreaTileQty {
   quantity: number;
 }
 
-export const initialState = mockTileData.find((obj) => obj.name === "ProFullCourt")
+export const initialState = mockTileData.find((obj) => obj.name === "Pro Full Court")
   ?.tileQty as AreaTileQty[];
 
 export const areaTileQtySlice = createSlice({
@@ -17,8 +17,8 @@ export const areaTileQtySlice = createSlice({
     changeCourtType: (state, action: PayloadAction<AreaTileQty[]>) => {
       return action.payload;
     },
+    // TODO: changeBorderWidth
   },
-  // TODO: changeBorderWidth
 });
 
 export const { changeCourtType } = areaTileQtySlice.actions;

--- a/src/store/reducer/priceBarSlice.ts
+++ b/src/store/reducer/priceBarSlice.ts
@@ -13,23 +13,23 @@ export const initialState: PriceBarState = {
   blocks: [
     {
       color: "#72818B",
-      quantity: 1277,
+      quantity: 1273,
     },
     {
       color: "#B61313",
-      quantity: 2576,
+      quantity: 2688,
     },
     {
       color: "#195955",
-      quantity: 1098,
+      quantity: 1000,
     },
     {
       color: "#2C4E8A",
-      quantity: 637,
+      quantity: 624,
     },
     {
       color: "#606F14",
-      quantity: 130,
+      quantity: 115,
     },
   ],
 };

--- a/src/utils/printPDF.ts
+++ b/src/utils/printPDF.ts
@@ -30,7 +30,10 @@ export const downloadToPDF = async () => {
     const center = (pageWidth / 2) as number;
     const marginX = (pageWidth - canvasWidth) / 2;
     const marginY = (pageHeight - canvasHeight) / 2;
-
+    const linkUrl = process.env.NEXT_PUBLIC_DESIGN_URL as string;
+    const link = linkUrl.includes("https://")
+      ? (linkUrl.split("https://").pop() as string)
+      : linkUrl;
     // header
     doc.setFillColor("#344C5C");
     doc.rect(0, 0, pageWidth, 90, "F");
@@ -57,22 +60,17 @@ export const downloadToPDF = async () => {
       align: "center",
     });
     doc.setFontSize(12);
-    doc.text(
-      "With the CourtCanva web  you can design your court easily,",
-      center,
-      pageHeight - 90,
-      {
-        align: "center",
-      }
-    );
+    doc.text("With the CourtCanva web you can design your court easily,", center, pageHeight - 90, {
+      align: "center",
+    });
     doc.text("CourtCanva will help you estimate price for your design. ", center, pageHeight - 75, {
       align: "center",
     });
     doc.setFillColor("#44BC86");
     doc.roundedRect(42, pageHeight - 60, 360, 37, 2, 2, "F");
     doc.setFontSize(20);
-    doc.textWithLink("uat.design.courtcanva.com", center, pageHeight - 37, {
-      url: "https://uat.design.courtcanva.com/",
+    doc.textWithLink(link, center, pageHeight - 37, {
+      url: linkUrl,
       align: "center",
     });
     doc.setFillColor("#EBD935");

--- a/src/utils/tileNumberCalculator.ts
+++ b/src/utils/tileNumberCalculator.ts
@@ -79,6 +79,7 @@ export const tileNumberCalculator = (
     }
   }
 
+  // TODO: refactor, avoid using forEach
   // transfer rgba to hex of colorResult
   colorResult.forEach((obj) => {
     obj.color && (obj.color = rgbaToHex(obj.color));


### PR DESCRIPTION
For our main six types of courts, use mock data for the results showing in the price bar instead of tile calculator, as the calculator may cause a bug in price estimation. UseTileCalculation and tielNumberCalculator were remained in the repo, because they can be used for courts with user-customized sizes.