### PR TITLE
fix: fix courtarea not shown in small and medium courts

### DIFF
--- a/src/components/BasketballCourt/CourtArea.tsx
+++ b/src/components/BasketballCourt/CourtArea.tsx
@@ -12,7 +12,13 @@ interface CourtAreaProps {
 
 const CourtArea: React.FC<CourtAreaProps> = ({ courtWidth, startPoint }) => {
   const { courtAreaYLength } = useStoreSelector((state) => state.courtSize);
-
+  let courtAreaOffset = 0;
+  // if width from backend <15k, change it 15k to ensure CourtArea render correctly
+  if (courtAreaYLength === 7000) {
+    courtAreaOffset = 4000;
+  } else if (courtAreaYLength === 5000) {
+    courtAreaOffset = 5000;
+  }
   const selectedColor = useStoreSelector((state) => state.courtColor.selectedColor);
   const courtAreaColor = getColor("courtArea");
   const dispatch = useDispatch();
@@ -26,7 +32,7 @@ const CourtArea: React.FC<CourtAreaProps> = ({ courtWidth, startPoint }) => {
       height={courtAreaYLength}
       fill={courtAreaColor}
       x={startPoint.X}
-      y={startPoint.Y}
+      y={startPoint.Y + courtAreaOffset}
       stroke="white"
       strokeWidth={courtWhiteLine}
       onClick={handleColorChange}

--- a/src/components/MediumCourt/index.tsx
+++ b/src/components/MediumCourt/index.tsx
@@ -11,6 +11,7 @@ import { useStoreSelector } from "@/store/hooks";
 import { useTileCount } from "../../hooks/useTileCount";
 import CourtDimension from "../BasketballCourt/CourtDimension";
 import BorderDimension from "../BasketballCourt/BorderDimension";
+import CourtArea from "../BasketballCourt/CourtArea";
 
 const MediumCourt = () => {
   const {
@@ -102,7 +103,7 @@ const MediumCourt = () => {
                     ctx.clip();
                   }}
                 >
-                  {/* <CourtArea startPoint={componentsStartPoint} courtWidth={courtAreaXLength} /> */}
+                  <CourtArea startPoint={componentsStartPoint} courtWidth={courtAreaXLength} />
                   <ThreePointArea startPoint={componentsStartPoint} />
                   <KeyArea startPoint={componentsStartPoint} />
                   <TopKeyArea startPoint={componentsStartPoint} />

--- a/src/components/SmallCourt/index.tsx
+++ b/src/components/SmallCourt/index.tsx
@@ -12,6 +12,7 @@ import { useTileCount } from "../../hooks/useTileCount";
 import CourtDimension from "../BasketballCourt/CourtDimension";
 import BorderDimension from "../BasketballCourt/BorderDimension";
 import DashedLine from "../BasketballCourt/DashedLine";
+import CourtArea from "../BasketballCourt/CourtArea";
 
 const SmallCourt = () => {
   const {
@@ -103,7 +104,7 @@ const SmallCourt = () => {
                     ctx.clip();
                   }}
                 >
-                  {/* <CourtArea startPoint={componentsStartPoint} courtWidth={courtAreaXLength} /> */}
+                  <CourtArea startPoint={componentsStartPoint} courtWidth={courtAreaXLength} />
                   <ThreePointArea startPoint={componentsStartPoint} />
                   <KeyArea startPoint={componentsStartPoint} />
                   <TopKeyArea startPoint={componentsStartPoint} />


### PR DESCRIPTION
Copied the code from branch 64 to solve the issue that the court area is not shown in small and medium courts. As this bug needs to be solved ASAP.
Before:
<img width="429" alt="image" src="https://user-images.githubusercontent.com/101085792/178629151-39bf50ef-5047-49fa-bdcb-068ba562a2c9.png">

After:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/101085792/178629105-c47906b9-6e3c-4558-91ba-effb4280fcfc.png">
