### PR TITLE
fix: fix tile block in price bar showing 0 when no border

### DIFF
--- a/src/components/PriceBar/TileColorBoard.tsx
+++ b/src/components/PriceBar/TileColorBoard.tsx
@@ -46,19 +46,23 @@ const TileColorBoard: React.FC = () => {
   const centers = useMemo(() => {
     if (!tileBlocks) return null;
 
-    return tileBlocks.map(({ color, quantity }) => (
-      <Center
-        key={color}
-        backgroundColor={color}
-        width={{ base: "40px", lg: "60px", xl: "85px" }}
-        height={{ base: "20px", lg: "25px", xl: "35px" }}
-        fontSize={{ base: "xs", xl: "sm" }}
-        color="white"
-        role="tileBlock"
-      >
-        {quantity}
-      </Center>
-    ));
+    return tileBlocks.map(({ color, quantity }) => {
+      if (quantity !== 0) {
+        return (
+          <Center
+            key={color}
+            backgroundColor={color}
+            width={{ base: "40px", lg: "60px", xl: "85px" }}
+            height={{ base: "20px", lg: "25px", xl: "35px" }}
+            fontSize={{ base: "xs", xl: "sm" }}
+            color="white"
+            role="tileBlock"
+          >
+            {quantity}
+          </Center>
+        );
+      }
+    });
   }, [tileBlocks]);
 
   return (


### PR DESCRIPTION
tile showing 0 bug fixed.
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/101085792/181134154-5d0d66e7-ba28-42e9-a8aa-389787826556.png">
