### PR TITLE
Fix/cc 66 resolve account conflicts

### DIFF
--- a/src/components/Login/accountConnection/index.tsx
+++ b/src/components/Login/accountConnection/index.tsx
@@ -16,11 +16,12 @@ import { api } from "@/utils/axios";
 import { GoogleLoginRes } from "@/components/Login/SelectLogin";
 import { updateUserInfo } from "@/store/reducer/userSlice";
 import { useStoreDispatch } from "@/store/hooks";
+import { IUser } from "@/interfaces/user";
 
 interface Props {
   existedUserInfo: GoogleLoginRes | null;
   setStep: Dispatch<SetStateAction<number>>;
-  updateLoginData: (data: GoogleLoginRes) => void;
+  updateLoginData: (data: IUser) => void;
   onClose: () => void;
 }
 
@@ -40,7 +41,13 @@ const AccountConnection: React.FC<Props> = ({
         email: existedUserInfo?.email,
       },
     });
-    const userInfo: GoogleLoginRes = axiosResponse.data;
+    const loginRes: GoogleLoginRes = axiosResponse.data;
+    const userInfo: IUser = {
+      userId: loginRes.userId,
+      email: loginRes.email,
+      firstName: loginRes.firstName,
+      lastName: loginRes.lastName,
+    };
     try {
       if (userInfo) {
         localStorage.setItem("UserInfo", JSON.stringify(userInfo));
@@ -61,9 +68,11 @@ const AccountConnection: React.FC<Props> = ({
           <Icon width="240px" height="180px" viewBox="120 0 550 550" role="logo">
             <MainLogoSvg />
           </Icon>
-          <Text fontSize="medium">An account with your Google email exists</Text>
+          <Text fontSize="17px" textAlign="center">
+            Account registered by this email exists
+          </Text>
           <Text fontSize="11px" textAlign="center" fontWeight="light" marginTop="15px">
-            Do you want to connect your account with Google?
+            To login with Google, please connect your existing account with your Google account
           </Text>
         </Flex>
       </ModalHeader>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -21,7 +21,6 @@ import { getDesignsTileData } from "@/store/reducer/designsTileListSlice";
 import { defaultCourt, setDefaultCourt } from "@/store/reducer/courtSpecDataSlice";
 import { defaultCourtColor, setDefaultCourtColor } from "@/store/reducer/tileSlice";
 import { changeDesignNameList } from "@/store/reducer/designNameSlice";
-import { googleUserMapping } from "@/utils/userMapping";
 import { userData } from "@/store/reducer/userSlice";
 import { useGetItemQuantityQuery } from "@/redux/api/cartApi";
 import { skipToken } from "@reduxjs/toolkit/dist/query";
@@ -53,12 +52,8 @@ const NavigationBar = () => {
       dispatch(getDesignsTileData([]));
       return;
     }
-    loginData.googleId
-      ? dispatch(updateUserInfo(googleUserMapping(loginData)))
-      : dispatch(updateUserInfo(loginData));
-    const design = loginData.googleId
-      ? await fetchDesignData(loginData.googleId)
-      : await fetchDesignData(loginData.userId);
+    dispatch(updateUserInfo(loginData));
+    const design = await fetchDesignData(loginData.userId);
     if (design.data === undefined) return;
     const { mappedDesignsData, mappedTileData, mappedNameList } = designMapping(design.data);
     dispatch(getDesignsData(mappedDesignsData));

--- a/src/interfaces/user.d.ts
+++ b/src/interfaces/user.d.ts
@@ -1,5 +1,5 @@
-export interface IGoogleUser {
-  googleId: string;
+export interface IUser {
+  userId: string;
   email: string;
   firstName: string;
   lastName: string;

--- a/src/utils/userMapping.ts
+++ b/src/utils/userMapping.ts
@@ -1,8 +1,0 @@
-import { IGoogleUser } from "@/interfaces/user";
-
-export const googleUserMapping = (item: IGoogleUser) => ({
-  userId: item.googleId,
-  email: item.email,
-  firstName: item.firstName,
-  lastName: item.lastName,
-});


### PR DESCRIPTION
1. This issue is to resolve the situation that: 
In the previous version, the front end regards accounts signed up with email and google by the same email as two separate accounts. If users log in with google, the front end will send the request by google id, or else by user id.

However, in our latest user account logic, the front end should regard accounts in the situation above as one same account, since they are connected.

2. this issue update UI of the modal of the account connection component based on requests from BA.
<img width="481" alt="image" src="https://user-images.githubusercontent.com/89760674/194067936-1695ecc6-560e-4289-b2d6-7f3278dac46e.png">