### PR TITLE
fix: reset failure before download

### DIFF
--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -66,7 +66,10 @@ const TopBar = () => {
   const handleDownload = () => {
     dispatch(switchSideBar(false));
     dispatch(resetAll());
-    downloadToPDF();
+    const downloadTimer = setTimeout(() => {
+      downloadToPDF();
+      clearTimeout(downloadTimer);
+    }, 500);
   };
 
   const handleChange = (val: number) => {


### PR DESCRIPTION
Before fixed, court design has not been reset and relocated at the center of the downloaded PDF. The reason is the canvas rendering layer is **asynchronous**. Even the code has set to reset the size of the court first, and then execute the download function, the image in the downloaded PDF is still the image that has not been reset.  

I didn't figure out a better way to avoid this, I just set a timer to perform the download function 0.5 second after resetting the size.