### PR TITLE
Feature/cc 25 user no pasword

### DIFF
--- a/src/__tests__/components/Login/EmailLogin.test.tsx
+++ b/src/__tests__/components/Login/EmailLogin.test.tsx
@@ -19,7 +19,7 @@ describe("Login", () => {
       const continueButton = screen.getByRole("button", { name: /continue/i });
       expect(logoEl).toBeInTheDocument();
       expect(screen.getByText("Continue with Email")).toBeInTheDocument();
-      expect(screen.getByText("Enter your email address!")).toBeInTheDocument();
+      expect(screen.getByText("Please enter your email address!")).toBeInTheDocument();
       expect(inputEl).toBeInTheDocument();
       expect(continueButton).toBeInTheDocument();
     });

--- a/src/components/Login/AccountConnection/index.tsx
+++ b/src/components/Login/AccountConnection/index.tsx
@@ -88,12 +88,11 @@ const AccountConnection: React.FC<Props> = ({
           <Icon width="240px" height="180px" viewBox="120 0 550 550" role="logo">
             <MainLogoSvg />
           </Icon>
-          <Text fontSize="large" textAlign="center">
-            Existing account found
+          <Text fontSize="17" textAlign="center">
+            Account registered by your email exists
           </Text>
           <Text fontSize="11px" textAlign="center" fontWeight="light" marginTop="15px">
-            An account registered by this email is existed, would you like to connect it with
-            Google?
+            To continue, please connect your existing account with your Google account
           </Text>
         </Flex>
       </ModalHeader>

--- a/src/components/Login/AccountConnection/index.tsx
+++ b/src/components/Login/AccountConnection/index.tsx
@@ -58,7 +58,7 @@ const AccountConnection: React.FC<Props> = ({
         lastName: loginRes.lastName,
       };
       toast({
-        title: "Connection success! Enjoy designing!",
+        title: "Connection successful! Enjoy designing!",
         status: "success",
         isClosable: true,
         position: "top",

--- a/src/components/Login/AccountConnection/index.tsx
+++ b/src/components/Login/AccountConnection/index.tsx
@@ -7,6 +7,7 @@ import {
   ModalFooter,
   ModalHeader,
   Text,
+  useToast,
 } from "@chakra-ui/react";
 import React, { Dispatch, SetStateAction } from "react";
 import MainLogoSvg from "@/assets/svg/CourtCanva-main-LOGO.svg";
@@ -33,25 +34,33 @@ const AccountConnection: React.FC<Props> = ({
   onClose,
   currentStep,
 }) => {
+  const toast = useToast();
   const dispatch = useStoreDispatch();
   // if this call is needed else where in the future, please move it to redux
   const onConnect = async () => {
-    const axiosResponse = await api("/user/connect", {
-      method: "put",
-      requestData: {
-        googleId: existedUserInfo?.googleId,
-        email: existedUserInfo?.email,
-      },
-    });
-    const loginRes: GoogleLoginRes = axiosResponse.data;
-    const userInfo: IUser = {
-      userId: loginRes.userId,
-      email: loginRes.email,
-      firstName: loginRes.firstName,
-      lastName: loginRes.lastName,
-    };
     try {
+      const axiosResponse = await api("/user/connect", {
+        method: "put",
+        requestData: {
+          googleId: existedUserInfo?.googleId,
+          email: existedUserInfo?.email,
+        },
+      });
+      const loginRes: GoogleLoginRes = axiosResponse.data;
+      const userInfo: IUser = {
+        userId: loginRes.userId,
+        email: loginRes.email,
+        firstName: loginRes.firstName,
+        lastName: loginRes.lastName,
+      };
       if (userInfo) {
+        toast({
+          title: "Account connected successfully!",
+          status: "success",
+          isClosable: true,
+        });
+        setStep(1);
+        onClose();
         localStorage.setItem("UserInfo", JSON.stringify(userInfo));
         dispatch(updateUserInfo(userInfo));
         updateLoginData(userInfo);

--- a/src/components/Login/AccountConnection/index.tsx
+++ b/src/components/Login/AccountConnection/index.tsx
@@ -69,7 +69,7 @@ const AccountConnection: React.FC<Props> = ({
       closeModal();
     } catch (err) {
       toast({
-        title: "Connection failed",
+        title: "Connection failed, please try again",
         status: "error",
         isClosable: true,
         position: "top",
@@ -88,11 +88,12 @@ const AccountConnection: React.FC<Props> = ({
           <Icon width="240px" height="180px" viewBox="120 0 550 550" role="logo">
             <MainLogoSvg />
           </Icon>
-          <Text fontSize="17px" textAlign="center">
-            Account registered by this email exists
+          <Text fontSize="large" textAlign="center">
+            Existing account found
           </Text>
           <Text fontSize="11px" textAlign="center" fontWeight="light" marginTop="15px">
-            To login with Google, please connect your existing account with your Google account
+            An account registered by this email is existed, would you like to connect it with
+            Google?
           </Text>
         </Flex>
       </ModalHeader>

--- a/src/components/Login/AccountConnection/index.tsx
+++ b/src/components/Login/AccountConnection/index.tsx
@@ -88,7 +88,7 @@ const AccountConnection: React.FC<Props> = ({
           <Icon width="240px" height="180px" viewBox="120 0 550 550" role="logo">
             <MainLogoSvg />
           </Icon>
-          <Text fontSize="17" textAlign="center">
+          <Text fontSize="17px" textAlign="center">
             Account registered by your email exists
           </Text>
           <Text fontSize="11px" textAlign="center" fontWeight="light" marginTop="15px">

--- a/src/components/Login/AccountConnection/index.tsx
+++ b/src/components/Login/AccountConnection/index.tsx
@@ -36,6 +36,10 @@ const AccountConnection: React.FC<Props> = ({
 }) => {
   const toast = useToast();
   const dispatch = useStoreDispatch();
+  const closeModal = () => {
+    onClose();
+    setStep(1);
+  };
   // if this call is needed else where in the future, please move it to redux
   const onConnect = async () => {
     try {
@@ -53,28 +57,29 @@ const AccountConnection: React.FC<Props> = ({
         firstName: loginRes.firstName,
         lastName: loginRes.lastName,
       };
-      if (userInfo) {
-        toast({
-          title: "Account connected successfully!",
-          status: "success",
-          isClosable: true,
-        });
-        setStep(1);
-        onClose();
-        localStorage.setItem("UserInfo", JSON.stringify(userInfo));
-        dispatch(updateUserInfo(userInfo));
-        updateLoginData(userInfo);
-        setStep(1);
-        onClose();
-      }
+      toast({
+        title: "Connection success! Enjoy designing!",
+        status: "success",
+        isClosable: true,
+        position: "top",
+      });
+      localStorage.setItem("UserInfo", JSON.stringify(userInfo));
+      dispatch(updateUserInfo(userInfo));
+      updateLoginData(userInfo);
+      closeModal();
     } catch (err) {
-      console.warn(err);
+      toast({
+        title: "Connection failed",
+        status: "error",
+        isClosable: true,
+        position: "top",
+      });
     }
   };
   return (
     <>
       <ModalOperator
-        handleCloseModal={() => setStep(1)}
+        handleCloseModal={closeModal}
         prevStep={() => setStep(1)}
         currentStep={currentStep}
       />

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -26,15 +26,17 @@ interface Props {
   setNeedPwd: React.Dispatch<React.SetStateAction<boolean>>;
   inputEmail: (input: string) => void;
   currentStep: string;
+  setUserId: React.Dispatch<React.SetStateAction<string>>;
 }
 
 interface checkResponse {
   findUser: boolean;
-  needPwd: boolean;
-  emailRes: {
+  needPwd?: boolean;
+  emailRes?: {
     status: string;
     message: string;
   };
+  userId?: string;
 }
 
 const EmailLogin: React.FC<Props> = ({
@@ -47,6 +49,7 @@ const EmailLogin: React.FC<Props> = ({
   setStep,
   currentStep,
   setNeedPwd,
+  setUserId,
 }) => {
   const [input, setInput] = useState("");
   const [isEmpty, setIsEmpty] = useState(true);
@@ -70,11 +73,12 @@ const EmailLogin: React.FC<Props> = ({
     try {
       const res: checkResponse = (await checkEmail(input)).data;
       setUserExisted(res.findUser);
-      if (res.findUser && res.needPwd) {
-        if (res.emailRes.status !== "PENDING") {
-          throw Error("Failed to send verification email");
-        }
+      if (res.findUser && res.needPwd && res.emailRes && res.userId) {
+        // if (res.emailRes.status !== "PENDING") {
+        //   throw Error("Failed to send verification email");
+        // }
         setNeedPwd(true);
+        setUserId(res.userId);
         setStep(4);
       } else {
         nextStep();

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -18,7 +18,7 @@ import ModalOperator from "./ModalOperater";
 
 interface Props {
   initialRef: React.LegacyRef<HTMLInputElement> | undefined;
-  onClose: any;
+  onClose: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   nextStep: () => void;
   prevStep: () => void;
@@ -69,11 +69,11 @@ const EmailLogin: React.FC<Props> = ({
   const handleEmailCheck = async () => {
     try {
       const res: checkResponse = (await checkEmail(input)).data;
-      res.findUser ? setUserExisted(true) : setUserExisted(false);
+      setUserExisted(res.findUser);
       if (res.findUser && res.needPwd) {
-        if (res.emailRes.status !== "PENDING") {
-          throw Error(res.emailRes.message);
-        }
+        // if (res.emailRes.status !== "PENDING") {
+        //   throw Error(res.emailRes.message);
+        // }
         setNeedPwd(true);
         setStep(4);
       } else {
@@ -84,6 +84,7 @@ const EmailLogin: React.FC<Props> = ({
         title: "network error",
         status: "error",
         isClosable: true,
+        position: "top",
       });
     }
   };
@@ -98,8 +99,8 @@ const EmailLogin: React.FC<Props> = ({
     }
   };
   const handleCloseModal = () => {
-    setStep(1);
     onClose();
+    setStep(1);
   };
   return (
     <>

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -31,6 +31,10 @@ interface Props {
 interface checkResponse {
   findUser: boolean;
   needPwd: boolean;
+  emailRes: {
+    status: string;
+    message: string;
+  };
 }
 
 const EmailLogin: React.FC<Props> = ({
@@ -67,6 +71,9 @@ const EmailLogin: React.FC<Props> = ({
       const res: checkResponse = (await checkEmail(input)).data;
       res.findUser ? setUserExisted(true) : setUserExisted(false);
       if (res.findUser && res.needPwd) {
+        if (res.emailRes.status !== "PENDING") {
+          throw Error(res.emailRes.message);
+        }
         setNeedPwd(true);
         setStep(4);
       } else {

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -20,17 +20,30 @@ interface Props {
   initialRef: React.LegacyRef<HTMLInputElement> | undefined;
   onClose: any;
   setStep: React.Dispatch<React.SetStateAction<number>>;
+  setPwdStep: () => void;
   nextStep: () => void;
   prevStep: () => void;
-  findUser: (isExisted: boolean) => void;
+  setUserExisted: React.Dispatch<React.SetStateAction<boolean>>;
   inputEmail: (input: string) => void;
   currentStep: string;
 }
 
-export default function EmailLogin(props: Props) {
-  const { initialRef, nextStep, prevStep, findUser, inputEmail, onClose, setStep, currentStep } =
-    props;
+interface checkResponse {
+  findUser: boolean;
+  needPwd: boolean;
+}
 
+const EmailLogin: React.FC<Props> = ({
+  initialRef,
+  nextStep,
+  prevStep,
+  setUserExisted,
+  inputEmail,
+  onClose,
+  setStep,
+  currentStep,
+  setPwdStep,
+}) => {
   const [input, setInput] = useState("");
   const [isEmpty, setIsEmpty] = useState(true);
   const [isValidEmail, setIsValidEmail] = useState(true);
@@ -51,9 +64,13 @@ export default function EmailLogin(props: Props) {
 
   const handleEmailCheck = async () => {
     try {
-      const { data } = await checkEmail(input);
-      data ? findUser(true) : findUser(false);
-      typeof data === "boolean" && nextStep();
+      const res: checkResponse = await checkEmail(input);
+      res.findUser ? setUserExisted(true) : setUserExisted(false);
+      if (res.findUser && res.needPwd) {
+        setPwdStep();
+      } else {
+        nextStep();
+      }
     } catch (err) {
       toast({
         title: "network error",
@@ -69,7 +86,7 @@ export default function EmailLogin(props: Props) {
     setIsValidEmail(validation);
     if (validation) {
       inputEmail(input);
-      handleEmailCheck();
+      handleEmailCheck().then();
     }
   };
   const handleCloseModal = () => {
@@ -126,4 +143,6 @@ export default function EmailLogin(props: Props) {
       </ModalBody>
     </>
   );
-}
+};
+
+export default EmailLogin;

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -95,7 +95,7 @@ const EmailLogin: React.FC<Props> = ({
     setIsValidEmail(validation);
     if (validation) {
       inputEmail(input);
-      handleEmailCheck().then();
+      handleEmailCheck();
     }
   };
   const handleCloseModal = () => {

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -20,10 +20,10 @@ interface Props {
   initialRef: React.LegacyRef<HTMLInputElement> | undefined;
   onClose: any;
   setStep: React.Dispatch<React.SetStateAction<number>>;
-  setPwdStep: () => void;
   nextStep: () => void;
   prevStep: () => void;
   setUserExisted: React.Dispatch<React.SetStateAction<boolean>>;
+  setNeedPwd: React.Dispatch<React.SetStateAction<boolean>>;
   inputEmail: (input: string) => void;
   currentStep: string;
 }
@@ -42,7 +42,7 @@ const EmailLogin: React.FC<Props> = ({
   onClose,
   setStep,
   currentStep,
-  setPwdStep,
+  setNeedPwd,
 }) => {
   const [input, setInput] = useState("");
   const [isEmpty, setIsEmpty] = useState(true);
@@ -64,10 +64,11 @@ const EmailLogin: React.FC<Props> = ({
 
   const handleEmailCheck = async () => {
     try {
-      const res: checkResponse = await checkEmail(input);
+      const res: checkResponse = (await checkEmail(input)).data;
       res.findUser ? setUserExisted(true) : setUserExisted(false);
       if (res.findUser && res.needPwd) {
-        setPwdStep();
+        setNeedPwd(true);
+        setStep(4);
       } else {
         nextStep();
       }

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -71,9 +71,9 @@ const EmailLogin: React.FC<Props> = ({
       const res: checkResponse = (await checkEmail(input)).data;
       setUserExisted(res.findUser);
       if (res.findUser && res.needPwd) {
-        // if (res.emailRes.status !== "PENDING") {
-        //   throw Error(res.emailRes.message);
-        // }
+        if (res.emailRes.status !== "PENDING") {
+          throw Error("Failed to send verification email");
+        }
         setNeedPwd(true);
         setStep(4);
       } else {
@@ -81,7 +81,7 @@ const EmailLogin: React.FC<Props> = ({
       }
     } catch (err) {
       toast({
-        title: "network error",
+        title: err instanceof Error ? err.message : "network error",
         status: "error",
         isClosable: true,
         position: "top",

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -103,7 +103,7 @@ const EmailLogin: React.FC<Props> = ({
       />
       <ModalHeader width="100%" marginTop="-20px">
         <Flex flexDir="column" alignItems="center" width="100%">
-          <Icon width="240px" height="180px" viewBox="120 0 600 600" role="logo">
+          <Icon width="240px" height="180px" viewBox="100 0 600 600" role="logo">
             <MainLogoSvg />
           </Icon>
           <Text fontSize="md" marginTop="10px">
@@ -115,7 +115,7 @@ const EmailLogin: React.FC<Props> = ({
       <ModalBody width="100%" marginTop="10px" marginBottom="30px">
         <FormControl display="flex" flexDirection="column">
           <FormLabel fontSize="sm" color={isValidEmail ? "black" : "red.500"}>
-            {isValidEmail ? "Enter your email address!" : "Please enter a valid email!"}
+            {isValidEmail ? "Please enter your email address!" : "Please enter a valid email!"}
           </FormLabel>
           <Input
             id="email"

--- a/src/components/Login/EmailVerification/index.tsx
+++ b/src/components/Login/EmailVerification/index.tsx
@@ -56,7 +56,6 @@ const EmailVerification: React.FC<Props> = ({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (needPwd) setPwdStep();
     if (otp.length < CODE_LENGTH) {
       setErrorMessage("Please Input a 6 digits number!");
       return;

--- a/src/components/Login/EmailVerification/index.tsx
+++ b/src/components/Login/EmailVerification/index.tsx
@@ -56,6 +56,7 @@ const EmailVerification: React.FC<Props> = ({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    if (needPwd) setPwdStep();
     if (otp.length < CODE_LENGTH) {
       setErrorMessage("Please Input a 6 digits number!");
       return;

--- a/src/components/Login/EmailVerification/index.tsx
+++ b/src/components/Login/EmailVerification/index.tsx
@@ -56,7 +56,7 @@ const EmailVerification: React.FC<Props> = ({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    needPwd ? setPwdStep() : nextStep();
+    if (needPwd) setPwdStep();
     if (otp.length < CODE_LENGTH) {
       setErrorMessage("Please Input a 6 digits number!");
       return;
@@ -64,11 +64,11 @@ const EmailVerification: React.FC<Props> = ({
     try {
       const { data } = await verifyOTP(userId, otp);
       if (data.tokens) {
+        if (needPwd) setPwdStep();
         localStorage.setItem("UserInfo", JSON.stringify(data));
         dispatch(updateUserInfo(data));
         updateLoginData(data);
         validation(true);
-        needPwd ? setPwdStep() : nextStep();
       } else {
         validation(false);
         nextStep();

--- a/src/components/Login/EmailVerification/index.tsx
+++ b/src/components/Login/EmailVerification/index.tsx
@@ -25,7 +25,7 @@ type Props = {
   currentStep: string;
   validation: (verified: boolean) => void;
   updateLoginData: (data: any) => void;
-  onClose: any;
+  onClose: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   userEmail: string;
   userId: string;
@@ -56,6 +56,7 @@ const EmailVerification: React.FC<Props> = ({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    needPwd ? setPwdStep() : nextStep();
     if (otp.length < CODE_LENGTH) {
       setErrorMessage("Please Input a 6 digits number!");
       return;
@@ -77,6 +78,7 @@ const EmailVerification: React.FC<Props> = ({
         title: "network error",
         status: "error",
         isClosable: true,
+        position: "top",
       });
     }
   };
@@ -90,6 +92,7 @@ const EmailVerification: React.FC<Props> = ({
         title: "network error",
         status: "error",
         isClosable: true,
+        position: "top",
       });
     }
     resetTimer();
@@ -99,8 +102,8 @@ const EmailVerification: React.FC<Props> = ({
     setOtp(verificationCode);
   };
   const handleCloseModal = () => {
-    setStep(1);
     onClose();
+    setStep(1);
   };
   const resetTimer = () => setTimer(60);
   useEffect(() => {

--- a/src/components/Login/EmailVerification/index.tsx
+++ b/src/components/Login/EmailVerification/index.tsx
@@ -30,29 +30,33 @@ type Props = {
   userEmail: string;
   userId: string;
   initialRef: React.MutableRefObject<null>;
+  needPwd: boolean;
+  setPwdStep: () => void;
 };
-const EmailVerification: React.FC<Props> = (props: Props) => {
+const EmailVerification: React.FC<Props> = ({
+  userEmail,
+  nextStep,
+  onClose,
+  setStep,
+  prevStep,
+  userId,
+  validation,
+  updateLoginData,
+  currentStep,
+  needPwd,
+  setPwdStep,
+}) => {
   const toast = useToast();
   const [otp, setOtp] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [timer, setTimer] = useState(60);
   const dispatch = useDispatch();
   const { verifyOTP, resendOTP } = useAuthRequest();
-  const {
-    userEmail,
-    nextStep,
-    onClose,
-    setStep,
-    prevStep,
-    userId,
-    validation,
-    updateLoginData,
-    currentStep,
-  } = props;
   const CODELENGTH = 6;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    if (needPwd) setPwdStep();
     if (otp.length < CODELENGTH) {
       setErrorMessage("Please Input a 6 digits number!");
       return;
@@ -64,7 +68,7 @@ const EmailVerification: React.FC<Props> = (props: Props) => {
         dispatch(updateUserInfo(data));
         updateLoginData(data);
         validation(true);
-        nextStep();
+        needPwd ? setPwdStep() : nextStep();
       } else {
         validation(false);
         nextStep();

--- a/src/components/Login/EmailVerification/index.tsx
+++ b/src/components/Login/EmailVerification/index.tsx
@@ -52,12 +52,12 @@ const EmailVerification: React.FC<Props> = ({
   const [timer, setTimer] = useState(60);
   const dispatch = useDispatch();
   const { verifyOTP, resendOTP } = useAuthRequest();
-  const CODELENGTH = 6;
+  const CODE_LENGTH = 6;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     if (needPwd) setPwdStep();
-    if (otp.length < CODELENGTH) {
+    if (otp.length < CODE_LENGTH) {
       setErrorMessage("Please Input a 6 digits number!");
       return;
     }
@@ -96,7 +96,7 @@ const EmailVerification: React.FC<Props> = ({
     resetTimer();
   };
   const handleOtpInput = (value: string) => {
-    const verificationCode = value.length > CODELENGTH ? value.substring(0, CODELENGTH) : value;
+    const verificationCode = value.length > CODE_LENGTH ? value.substring(0, CODE_LENGTH) : value;
     setOtp(verificationCode);
   };
   const handleCloseModal = () => {

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -13,6 +13,7 @@ import MainLogoSvg from "@/assets/svg/CourtCanva-main-LOGO.svg";
 import PwdInputGroup from "@/components/Login/PwdInputGroup";
 import React, { useState } from "react";
 import { updateUser } from "@/components/Login/helpers/userRequests";
+import validatePwd from "@/components/Login/helpers/validatePwd";
 
 type Props = {
   onClose: () => void;
@@ -43,28 +44,14 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
       setErrorMessage("Please fill all fields with asterisk!");
       return;
     }
-    if (password !== confirmPassword) {
-      setWeakPasswordMsg("");
-      setErrorMessage("Password does not match!");
-      return;
-    }
-    // regular expression from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
-    const passwordRegExp =
-      /^(?=.*\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[ `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~])[a-zA-Z\d `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]{8,}$/; // eslint-disable-line
-    if (!passwordRegExp.test(password)) {
-      setErrorMessage("");
-      setWeakPasswordMsg(
-        "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number and one special character!"
-      );
-      return;
-    }
+    if (!validatePwd(password, confirmPassword, setWeakPasswordMsg, setErrorMessage)) return;
     try {
       await updateUser({
         email: userEmail,
         password: password,
       });
       toast({
-        title: "Operation success! Please login again",
+        title: "Operation successful! Please login again",
         status: "success",
         isClosable: true,
         position: "top",

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -54,7 +54,7 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
     if (!passwordRegExp.test(password)) {
       setErrorMessage("");
       setWeakPasswordMsg(
-        "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number!"
+        "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number and one special character!"
       );
       return;
     }

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -15,7 +15,6 @@ import React, { useState } from "react";
 import { updateUser } from "@/components/Login/helpers/userRequests";
 
 type Props = {
-  prevStep: () => void;
   onClose: any;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   userEmail: string;
@@ -25,7 +24,6 @@ type Props = {
 const ExistedAccountPwdSetting: React.FC<Props> = ({
   setStep,
   onClose,
-  prevStep,
   currentStep,
   userEmail,
 }) => {
@@ -85,7 +83,7 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
     <>
       <ModalOperator
         handleCloseModal={handleCloseModal}
-        prevStep={prevStep}
+        prevStep={() => setStep(1)}
         currentStep={currentStep}
       />
       <ModalHeader width="100%" marginTop="-20px">
@@ -93,9 +91,11 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
           <Icon width="240px" height="180px" viewBox="0 0 800 600" role="logo">
             <MainLogoSvg />
           </Icon>
-          <Text fontSize="sm" textAlign="center">
-            To login by email, please set password for
-            <Text color="brand.secondary">{userEmail}</Text>
+          <Text fontSize="xl" textAlign="center">
+            Please set your password
+            <Text color="brand.secondary" fontSize="sm">
+              {userEmail}
+            </Text>
           </Text>
           <Divider />
           <Text fontSize="md" color="red.500">

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -14,6 +14,7 @@ import PwdInputGroup from "@/components/Login/PwdInputGroup";
 import React, { useState } from "react";
 import { updateUser } from "@/components/Login/helpers/userRequests";
 import validatePwd from "@/components/Login/helpers/validatePwd";
+import { AxiosResponse } from "axios";
 
 type Props = {
   onClose: () => void;
@@ -47,26 +48,26 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
       return;
     }
     if (!validatePwd(password, confirmPassword, setWeakPasswordMsg, setErrorMessage)) return;
-    try {
-      await updateUser({
-        userId: userId,
-        password: password,
-      });
-      toast({
-        title: "Operation successful! Please login again",
-        status: "success",
-        isClosable: true,
-        position: "top",
-      });
-      closeModal();
-    } catch (err) {
+    const res: AxiosResponse = await updateUser({
+      userId: userId,
+      password: password,
+    });
+    if (res.status !== 200) {
       toast({
         title: "Operation failed, please try again",
         status: "error",
         isClosable: true,
         position: "top",
       });
+      return;
     }
+    toast({
+      title: "Operation successful! Please login again",
+      status: "success",
+      isClosable: true,
+      position: "top",
+    });
+    closeModal();
   };
   return (
     <>

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -60,13 +60,13 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
       return;
     }
     try {
-      const { data } = await updateUser({
+      const res = await updateUser({
         email: userEmail,
         password: password,
       });
-      if (data) {
+      if (res.status === 200) {
         toast({
-          title: "Password set successfully, please login again",
+          title: "Password set successfully! Please login again",
           status: "success",
           isClosable: true,
         });

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -15,7 +15,7 @@ import React, { useState } from "react";
 import { updateUser } from "@/components/Login/helpers/userRequests";
 
 type Props = {
-  onClose: any;
+  onClose: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   userEmail: string;
   currentStep: string;
@@ -27,9 +27,9 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
   currentStep,
   userEmail,
 }) => {
-  const handleCloseModal = () => {
-    setStep(1);
+  const closeModal = () => {
     onClose();
+    setStep(1);
   };
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -59,31 +59,30 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
       return;
     }
     try {
-      const res = await updateUser({
+      await updateUser({
         email: userEmail,
         password: password,
       });
-      if (res.status === 200) {
-        toast({
-          title: "Password set successfully! Please login again",
-          status: "success",
-          isClosable: true,
-        });
-        setStep(1);
-        onClose();
-      }
+      toast({
+        title: "Operation success! Please login again",
+        status: "success",
+        isClosable: true,
+        position: "top",
+      });
+      closeModal();
     } catch (err) {
       toast({
         title: "network error",
         status: "error",
         isClosable: true,
+        position: "top",
       });
     }
   };
   return (
     <>
       <ModalOperator
-        handleCloseModal={handleCloseModal}
+        handleCloseModal={closeModal}
         prevStep={() => setStep(1)}
         currentStep={currentStep}
       />

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -49,7 +49,8 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
       return;
     }
     // regular expression from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
-    const passwordRegExp = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/;
+    const passwordRegExp =
+      /^(?=.*\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[ `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~])[a-zA-Z\d `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]{8,}$/; // eslint-disable-line
     if (!passwordRegExp.test(password)) {
       setErrorMessage("");
       setWeakPasswordMsg(

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -20,6 +20,7 @@ type Props = {
   setStep: React.Dispatch<React.SetStateAction<number>>;
   userEmail: string;
   currentStep: string;
+  userId: string;
 };
 
 const ExistedAccountPwdSetting: React.FC<Props> = ({
@@ -27,6 +28,7 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
   onClose,
   currentStep,
   userEmail,
+  userId,
 }) => {
   const closeModal = () => {
     onClose();
@@ -47,7 +49,7 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
     if (!validatePwd(password, confirmPassword, setWeakPasswordMsg, setErrorMessage)) return;
     try {
       await updateUser({
-        email: userEmail,
+        userId: userId,
         password: password,
       });
       toast({

--- a/src/components/Login/ExistedAccountPwdSetting/index.tsx
+++ b/src/components/Login/ExistedAccountPwdSetting/index.tsx
@@ -59,7 +59,7 @@ const ExistedAccountPwdSetting: React.FC<Props> = ({
       closeModal();
     } catch (err) {
       toast({
-        title: "network error",
+        title: "Operation failed, please try again",
         status: "error",
         isClosable: true,
         position: "top",

--- a/src/components/Login/LoginWithPwd.tsx
+++ b/src/components/Login/LoginWithPwd.tsx
@@ -1,4 +1,13 @@
-import { ModalHeader, ModalBody, Flex, Text, Icon, Divider, Button } from "@chakra-ui/react";
+import {
+  ModalHeader,
+  ModalBody,
+  Flex,
+  Text,
+  Icon,
+  Divider,
+  Button,
+  useToast,
+} from "@chakra-ui/react";
 import MainLogoSvg from "@/assets/svg/CourtCanva-main-LOGO.svg";
 import React, { useState } from "react";
 import PwdInputGroup from "./PwdInputGroup";
@@ -10,7 +19,7 @@ import { updateUserInfo } from "@/store/reducer/userSlice";
 type Props = {
   prevStep: () => void;
   nextStep: () => void;
-  onClose: any;
+  onClose: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   userEmail: string;
   initialRef: React.MutableRefObject<null>;
@@ -34,10 +43,11 @@ const LoginWithPwd: React.FC<Props> = (props: Props) => {
   const [isLoginFail, setIsLoginFail] = useState(false);
   const { userLogin, resendOTP } = useAuthRequest();
   const dispatch = useDispatch();
+  const toast = useToast();
 
-  const handleCloseModal = () => {
-    setStep(1);
+  const closeModal = () => {
     onClose();
+    setStep(1);
   };
   const handlePassword = (value: string) => {
     setIsLoginFail(false);
@@ -56,8 +66,13 @@ const LoginWithPwd: React.FC<Props> = (props: Props) => {
         localStorage.setItem("UserInfo", JSON.stringify(data));
         dispatch(updateUserInfo(data));
         updateLoginData(data);
-        setStep(1);
-        onClose();
+        toast({
+          title: "Login successful! Enjoy designing!",
+          status: "success",
+          isClosable: true,
+          position: "top",
+        });
+        closeModal();
       } else {
         await resendOTP(data.userId, userEmail);
         nextStep();
@@ -68,11 +83,7 @@ const LoginWithPwd: React.FC<Props> = (props: Props) => {
   };
   return (
     <>
-      <ModalOperator
-        handleCloseModal={handleCloseModal}
-        prevStep={prevStep}
-        currentStep={currentStep}
-      />
+      <ModalOperator handleCloseModal={closeModal} prevStep={prevStep} currentStep={currentStep} />
       <ModalHeader width="100%" marginTop="-20px">
         <Flex flexDir="column" alignItems="center">
           <Icon width="240px" height="180px" viewBox="0 0 800 600" role="logo">

--- a/src/components/Login/Register.tsx
+++ b/src/components/Login/Register.tsx
@@ -16,6 +16,7 @@ import React, { useState } from "react";
 import PwdInputGroup from "./PwdInputGroup";
 import ModalOperator from "./ModalOperater";
 import useAuthRequest from "./helpers/authRequest";
+import validatePwd from "@/components/Login/helpers/validatePwd";
 
 type Props = {
   nextStep: () => void;
@@ -45,21 +46,7 @@ const Register: React.FC<Props> = (props: Props) => {
       setErrorMessage("Please fill all fields with asterisk!");
       return;
     }
-    if (password !== confirmPassword) {
-      setWeakPasswordMsg("");
-      setErrorMessage("Password does not match!");
-      return;
-    }
-    // regular expression from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
-    const passwordRegExp =
-      /^(?=.*\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[ `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~])[a-zA-Z\d `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]{8,}$/; // eslint-disable-line
-    if (!passwordRegExp.test(password)) {
-      setErrorMessage("");
-      setWeakPasswordMsg(
-        "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number and one special character!"
-      );
-      return;
-    }
+    if (!validatePwd(password, confirmPassword, setWeakPasswordMsg, setErrorMessage)) return;
     try {
       const userInfo = {
         email: userEmail,

--- a/src/components/Login/Register.tsx
+++ b/src/components/Login/Register.tsx
@@ -21,7 +21,7 @@ type Props = {
   nextStep: () => void;
   prevStep: () => void;
   getUserId: (userId: string) => void;
-  onClose: any;
+  onClose: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   userEmail: string;
   initialRef: React.MutableRefObject<null>;
@@ -78,6 +78,7 @@ const Register: React.FC<Props> = (props: Props) => {
         title: "network error",
         status: "error",
         isClosable: true,
+        position: "top",
       });
     }
   };

--- a/src/components/Login/SelectLogin.tsx
+++ b/src/components/Login/SelectLogin.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   Icon,
   Link,
+  useToast,
 } from "@chakra-ui/react";
 import MainLogoSvg from "@/assets/svg/CourtCanva-main-LOGO.svg";
 import { IconContext } from "react-icons";
@@ -44,7 +45,7 @@ const SelectLogin: React.FC<Props> = ({
   connectionStep,
 }) => {
   const dispatch = useDispatch();
-
+  const toast = useToast();
   // Send request to backend after the request from front-end has been approved by Google
   /* istanbul ignore next */
   const handleSuccess = async (codeResponse: any) => {
@@ -59,12 +60,23 @@ const SelectLogin: React.FC<Props> = ({
         localStorage.setItem("UserInfo", JSON.stringify(googleLoginRes));
         dispatch(updateUserInfo(googleLoginRes));
         updateLoginData(googleLoginRes);
+        toast({
+          title: "Login successful! Enjoy designing!",
+          status: "success",
+          isClosable: true,
+          position: "top",
+        });
         onClose();
       } else {
         connectionStep(googleLoginRes);
       }
     } catch (err) {
-      console.warn(err);
+      toast({
+        title: "Login failed, please try again",
+        status: "error",
+        isClosable: true,
+        position: "top",
+      });
     }
   };
 

--- a/src/components/Login/existedAccountPwdSetting/index.tsx
+++ b/src/components/Login/existedAccountPwdSetting/index.tsx
@@ -1,46 +1,46 @@
+import ModalOperator from "@/components/Login/ModalOperater";
 import {
-  ModalHeader,
-  ModalBody,
-  Flex,
-  Text,
-  Icon,
-  Divider,
-  FormControl,
-  FormLabel,
-  Input,
   Button,
+  Divider,
+  Flex,
+  Icon,
+  ModalBody,
+  ModalHeader,
+  Text,
   useToast,
 } from "@chakra-ui/react";
 import MainLogoSvg from "@/assets/svg/CourtCanva-main-LOGO.svg";
+import PwdInputGroup from "@/components/Login/PwdInputGroup";
 import React, { useState } from "react";
-import PwdInputGroup from "./PwdInputGroup";
-import ModalOperator from "./ModalOperater";
-import useAuthRequest from "./helpers/authRequest";
+import { updateUser } from "@/components/Login/helpers/userRequests";
 
 type Props = {
-  nextStep: () => void;
   prevStep: () => void;
-  getUserId: (userId: string) => void;
   onClose: any;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   userEmail: string;
-  initialRef: React.MutableRefObject<null>;
   currentStep: string;
 };
 
-const Register: React.FC<Props> = (props: Props) => {
-  const { nextStep, prevStep, userEmail, onClose, setStep, getUserId, currentStep } = props;
+const ExistedAccountPwdSetting: React.FC<Props> = ({
+  setStep,
+  onClose,
+  prevStep,
+  currentStep,
+  userEmail,
+}) => {
+  const handleCloseModal = () => {
+    setStep(1);
+    onClose();
+  };
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
   const [weakPasswordMsg, setWeakPasswordMsg] = useState("");
-  const { userRegister } = useAuthRequest();
   const toast = useToast();
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (firstName === "" || lastName === "" || password === "" || confirmPassword === "") {
+    if (password === "" || confirmPassword === "") {
       setWeakPasswordMsg("");
       setErrorMessage("Please fill all fields with asterisk!");
       return;
@@ -60,18 +60,19 @@ const Register: React.FC<Props> = (props: Props) => {
       return;
     }
     try {
-      const userInfo = {
+      const { data } = await updateUser({
         email: userEmail,
-        password,
-        firstName,
-        lastName,
-      };
-      const { data } = await userRegister(userInfo);
-      if (data.status !== "PENDING") {
-        throw Error("Failed to send email.");
+        password: password,
+      });
+      if (data) {
+        toast({
+          title: "Password set successfully, please login again",
+          status: "success",
+          isClosable: true,
+        });
+        setStep(1);
+        onClose();
       }
-      getUserId(data.data.userId);
-      nextStep();
     } catch (err) {
       toast({
         title: "network error",
@@ -80,11 +81,6 @@ const Register: React.FC<Props> = (props: Props) => {
       });
     }
   };
-  const handleCloseModal = () => {
-    setStep(1);
-    onClose();
-  };
-
   return (
     <>
       <ModalOperator
@@ -98,7 +94,7 @@ const Register: React.FC<Props> = (props: Props) => {
             <MainLogoSvg />
           </Icon>
           <Text fontSize="sm" textAlign="center">
-            Sign up with
+            To login by email, please set password for
             <Text color="brand.secondary">{userEmail}</Text>
           </Text>
           <Divider />
@@ -110,24 +106,6 @@ const Register: React.FC<Props> = (props: Props) => {
       <ModalBody>
         <Flex flexDir="column" alignItems="center">
           <form style={{ marginBottom: "30px", width: "300px" }} onSubmit={handleSubmit}>
-            <Flex gap="10px">
-              <FormControl isRequired>
-                <FormLabel>First name</FormLabel>
-                <Input
-                  placeholder="First name"
-                  value={firstName}
-                  onChange={(event) => setFirstName(event?.currentTarget.value)}
-                />
-              </FormControl>
-              <FormControl isRequired>
-                <FormLabel>Last name</FormLabel>
-                <Input
-                  placeholder="Last name"
-                  value={lastName}
-                  onChange={(event) => setLastName(event?.currentTarget.value)}
-                />
-              </FormControl>
-            </Flex>
             <PwdInputGroup
               label="Password"
               value={password}
@@ -144,7 +122,7 @@ const Register: React.FC<Props> = (props: Props) => {
               </Text>
             )}
             <Button variant="shareBtn" width="300px" marginTop="20px" onClick={handleSubmit}>
-              Create Account
+              Submit
             </Button>
           </form>
         </Flex>
@@ -153,4 +131,4 @@ const Register: React.FC<Props> = (props: Props) => {
   );
 };
 
-export default Register;
+export default ExistedAccountPwdSetting;

--- a/src/components/Login/helpers/userRequests.ts
+++ b/src/components/Login/helpers/userRequests.ts
@@ -1,0 +1,27 @@
+import { api } from "@/utils/axios";
+
+interface updateInfo {
+  userId?: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  password?: string;
+}
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) return error;
+  return Object(error);
+};
+const updateUser = async (updateInfo: updateInfo) => {
+  try {
+    return await api("/user", {
+      method: "put",
+      requestData: { ...updateInfo },
+    });
+  } catch (error) {
+    const err = getErrorMessage(error);
+    return err.response;
+  }
+};
+
+export { updateUser };

--- a/src/components/Login/helpers/userRequests.ts
+++ b/src/components/Login/helpers/userRequests.ts
@@ -1,18 +1,27 @@
 import { api } from "@/utils/axios";
 
 interface updateInfo {
-  userId?: string;
+  userId: string;
   email?: string;
   firstName?: string;
   lastName?: string;
   password?: string;
 }
 
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) return error;
+  return Object(error);
+};
+
 const updateUser = async (updateInfo: updateInfo) => {
-  return await api("/user", {
-    method: "put",
-    requestData: { ...updateInfo },
-  });
+  try {
+    return await api("/user", {
+      method: "put",
+      requestData: { ...updateInfo },
+    });
+  } catch (err) {
+    return getErrorMessage(err).response;
+  }
 };
 
 export { updateUser };

--- a/src/components/Login/helpers/userRequests.ts
+++ b/src/components/Login/helpers/userRequests.ts
@@ -8,20 +8,11 @@ interface updateInfo {
   password?: string;
 }
 
-const getErrorMessage = (error: unknown) => {
-  if (error instanceof Error) return error;
-  return Object(error);
-};
 const updateUser = async (updateInfo: updateInfo) => {
-  try {
-    return await api("/user", {
-      method: "put",
-      requestData: { ...updateInfo },
-    });
-  } catch (error) {
-    const err = getErrorMessage(error);
-    return err.response;
-  }
+  return await api("/user", {
+    method: "put",
+    requestData: { ...updateInfo },
+  });
 };
 
 export { updateUser };

--- a/src/components/Login/helpers/validatePwd.ts
+++ b/src/components/Login/helpers/validatePwd.ts
@@ -1,0 +1,27 @@
+import React from "react";
+
+const validatePwd = (
+  password: string,
+  confirmPassword: string,
+  setWeakPasswordMsg: React.Dispatch<React.SetStateAction<string>>,
+  setErrorMessage: React.Dispatch<React.SetStateAction<string>>
+): boolean => {
+  if (password !== confirmPassword) {
+    setWeakPasswordMsg("");
+    setErrorMessage("Password does not match!");
+    return false;
+  }
+  // regular expression from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
+  const passwordRegExp =
+    /^(?=.*\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[ `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~])[a-zA-Z\d `!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]{8,}$/; // eslint-disable-line
+  if (!passwordRegExp.test(password)) {
+    setErrorMessage("");
+    setWeakPasswordMsg(
+      "Password must contain at least 8 characters, one uppercase letter, one lowercase letter, one number and one special character!"
+    );
+    return false;
+  }
+  return true;
+};
+
+export default validatePwd;

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -76,6 +76,7 @@ const LoginModalContent = (props: Props) => {
               setUserEmail(email);
             }}
             setNeedPwd={setNeedPwd}
+            setUserId={setUserId}
           />
         );
       case 3:
@@ -153,6 +154,7 @@ const LoginModalContent = (props: Props) => {
             setStep={setStep}
             userEmail={userEmail}
             currentStep={stepName.ExistedAccountPwdSetting}
+            userId={userId}
           />
         );
     }

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -44,11 +44,9 @@ const LoginModalContent = (props: Props) => {
     setExistedUserInfo(existedUserInfo);
     setStep(6);
   };
-
-  const findUser = (isUserExisted: boolean) => {
-    setUserExisted(isUserExisted);
+  const setPwdStep = () => {
+    return;
   };
-
   const modalContent = () => {
     switch (step) {
       case 1:
@@ -70,10 +68,11 @@ const LoginModalContent = (props: Props) => {
             nextStep={nextStep}
             prevStep={prevStep}
             initialRef={initialRef}
-            findUser={findUser}
+            setUserExisted={setUserExisted}
             inputEmail={(email: string) => {
               setUserEmail(email);
             }}
+            setPwdStep={setPwdStep}
           />
         );
       case 3:

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -149,7 +149,6 @@ const LoginModalContent = (props: Props) => {
       case 7:
         return (
           <ExistedAccountPwdSetting
-            prevStep={prevStep}
             onClose={onClose}
             setStep={setStep}
             userEmail={userEmail}

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -6,8 +6,8 @@ import LoginWithPwd from "./LoginWithPwd";
 import Register from "./Register";
 import EmailVerification from "./EmailVerification";
 import VerificationResult from "./EmailVerification/VerificationResult";
-import AccountConnection from "@/components/Login/accountConnection";
-import ExistedAccountPwdSetting from "@/components/Login/existedAccountPwdSetting";
+import AccountConnection from "@/components/Login/AccountConnection";
+import ExistedAccountPwdSetting from "@/components/Login/ExistedAccountPwdSetting";
 
 interface Props {
   isOpen: boolean;

--- a/src/components/Login/index.tsx
+++ b/src/components/Login/index.tsx
@@ -7,6 +7,7 @@ import Register from "./Register";
 import EmailVerification from "./EmailVerification";
 import VerificationResult from "./EmailVerification/VerificationResult";
 import AccountConnection from "@/components/Login/accountConnection";
+import ExistedAccountPwdSetting from "@/components/Login/existedAccountPwdSetting";
 
 interface Props {
   isOpen: boolean;
@@ -21,6 +22,7 @@ export enum stepName {
   EmailVerification = "EmailVerification",
   VerificationResult = "VerificationResult",
   AccountConnection = "AccountConnection",
+  ExistedAccountPwdSetting = "ExistedAccountPwdSetting",
 }
 
 const LoginModalContent = (props: Props) => {
@@ -33,6 +35,7 @@ const LoginModalContent = (props: Props) => {
   const [userEmail, setUserEmail] = useState("");
   const [userId, setUserId] = useState("");
   const [verified, setVerified] = useState(true);
+  const [needPwd, setNeedPwd] = useState<boolean>(false);
   const [existedUserInfo, setExistedUserInfo] = useState<GoogleLoginRes | null>(null);
   const nextStep = () => {
     setStep((step) => step + 1);
@@ -45,7 +48,7 @@ const LoginModalContent = (props: Props) => {
     setStep(6);
   };
   const setPwdStep = () => {
-    return;
+    setStep(7);
   };
   const modalContent = () => {
     switch (step) {
@@ -72,7 +75,7 @@ const LoginModalContent = (props: Props) => {
             inputEmail={(email: string) => {
               setUserEmail(email);
             }}
-            setPwdStep={setPwdStep}
+            setNeedPwd={setNeedPwd}
           />
         );
       case 3:
@@ -119,6 +122,8 @@ const LoginModalContent = (props: Props) => {
             validation={(verified: boolean) => {
               setVerified(verified);
             }}
+            needPwd={needPwd}
+            setPwdStep={setPwdStep}
           />
         );
       case 5:
@@ -139,6 +144,16 @@ const LoginModalContent = (props: Props) => {
             onClose={onClose}
             existedUserInfo={existedUserInfo}
             setStep={setStep}
+          />
+        );
+      case 7:
+        return (
+          <ExistedAccountPwdSetting
+            prevStep={prevStep}
+            onClose={onClose}
+            setStep={setStep}
+            userEmail={userEmail}
+            currentStep={stepName.ExistedAccountPwdSetting}
           />
         );
     }


### PR DESCRIPTION
1. Resolve the situation where a user has already registered an account through google and then tries to log in through email. 

Previously, the app would indicate the user to input passwords. However, the user hasn't set passwords.

In the latest version, the app will indicate user to set passwords after verifying the email.

2. Fix bugs when a user registers by email without finishing email verification (user is created in the database, but user.isActivated = false). Then this user tries to log in with google.
In the latest business logic (already finished previously), the user registering without verifying email shouldn't be seen as successfully registered on this user's side; this user should be indicated to register again as a brand new user when this user tries to register with the same email, although the information of this user is already saved in database.

However, when this user tries to log in with google in the above situation, the app will make a mistake to indicate this user to connect the account.

The bug above is fixed.

3. Add useToast() to more register & login flow

4. Make some minor UI refinements.

<img width="461" alt="image" src="https://user-images.githubusercontent.com/89760674/195336094-6c8b8dc6-2791-437b-830c-f8349a24bae3.png">

