### PR TITLE
add preview image to share template page

### DIFF
--- a/src/__tests__/utils/generateNewTemplate.test.ts
+++ b/src/__tests__/utils/generateNewTemplate.test.ts
@@ -9,7 +9,7 @@ describe("generateNewTemplate", () => {
       user_id: "123456",
       description: "This is description",
       design: {
-        _id: "",
+        designer: "Zark",
         user_id: "",
         designName: "Cecilia's Court",
         tileColor: [],
@@ -34,8 +34,10 @@ describe("generateNewTemplate", () => {
         CourtType: "basketball",
       },
     };
+    const designer = "Zark";
     const userId = "123456";
     const name = "Cecilia's Court";
+    const imageUrl = "image_url"
     const description = "This is description";
     const selectedCourtTileData: Court[] = [];
     const selectedCourt: CourtSizeState = {
@@ -58,7 +60,9 @@ describe("generateNewTemplate", () => {
       name,
       description,
       selectedCourtTileData,
-      selectedCourt
+      selectedCourt,
+      imageUrl,
+      designer
     );
     expect(newTemplate).toEqual(mockTemplateData);
   });

--- a/src/components/CreateTemplate/index.tsx
+++ b/src/components/CreateTemplate/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable require-jsdoc */
 import { useStoreSelector } from "@/store/hooks";
+import Image from "next/image";
 import {
   Button,
   Modal,
@@ -20,6 +21,7 @@ import {
   useDisclosure,
   FormHelperText,
   FormErrorMessage,
+  useToast,
 } from "@chakra-ui/react";
 import React, { useRef, useState } from "react";
 import { FaUserCircle } from "react-icons/fa";
@@ -33,6 +35,8 @@ import {
   MAX_DESCRIPTION_LEN,
 } from "@/constants/templateCreate";
 import ErrorMsg from "./ErrorMsg";
+import { upLoadScreenshot } from "@/utils/manageExternalImage";
+import { FcRemoveImage } from "react-icons/fc";
 
 interface Props {
   isOpen: boolean;
@@ -47,7 +51,10 @@ function CreateTemplate({ isOpen, onClose }: Props) {
   const { userId, firstName, lastName } = useStoreSelector((state) => state.user);
   const { activeCourt: selectedCourt } = useStoreSelector((state) => state.courtSpecData);
   const { court: selectedCourtTileData } = useStoreSelector((state) => state.tile.present);
+  const { courtDataUrl } = useStoreSelector((state) => state.canvasControl);
   const [addTemplate] = useAddTemplateMutation();
+  const toast = useToast();
+  const designerName = `${firstName} ${lastName}`;
 
   const courtType = "basketball";
   const {
@@ -60,6 +67,17 @@ function CreateTemplate({ isOpen, onClose }: Props) {
     setInputError(INPUT_ERR_INIT);
     setTextAreaLen(0);
     onClose();
+  };
+
+  const generateToast = (title: string) => {
+    return toast({
+      title,
+      description: "Please try again or contact IT support",
+      status: "error",
+      duration: 9000,
+      isClosable: true,
+      position: "bottom",
+    });
   };
 
   const checkNameLength = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -90,12 +108,19 @@ function CreateTemplate({ isOpen, onClose }: Props) {
       }));
       return;
     }
+    if (!courtDataUrl) {
+      const title = `Fail to get courtDataUrl`;
+      return generateToast(title);
+    }
+    const imageUrl = await upLoadScreenshot(courtDataUrl, toast);
     const packedTemplate = generateNewTemplate(
       userId,
       courtName,
       description,
       selectedCourtTileData,
-      selectedCourt
+      selectedCourt,
+      imageUrl,
+      designerName
     );
     await addTemplate(packedTemplate)
       .unwrap()
@@ -104,7 +129,8 @@ function CreateTemplate({ isOpen, onClose }: Props) {
         closeWindow();
       })
       .catch((_err) => {
-        alert("Whoops! unsuccessful publish your template, please try again!");
+        const title = `Fail to publish your template`;
+        return generateToast(title);
       });
   };
 
@@ -118,16 +144,18 @@ function CreateTemplate({ isOpen, onClose }: Props) {
           <ModalBody padding="0.5rem 1.5rem">
             <FormLabel>Court Preview:</FormLabel>
             <Flex
-              fontSize="2rem"
-              fontWeight="500"
               width="20rem"
               height="11rem"
-              backgroundColor="orange"
-              justifyContent="center"
-              alignItems="center"
               margin="1.8rem auto"
+              alignItems="center"
+              justifyContent="center"
+              position="relative"
             >
-              Court Image
+              {courtDataUrl ? (
+                <Image src={courtDataUrl} alt="court preview" layout="fill" objectFit="contain" />
+              ) : (
+                <FcRemoveImage size={42} />
+              )}
             </Flex>
             <Flex gap="1.5rem" justifyContent="center" flexWrap="wrap">
               <Badge margin="1rem" colorScheme="green">
@@ -166,7 +194,7 @@ function CreateTemplate({ isOpen, onClose }: Props) {
                     overflow="hidden"
                     textOverflow="ellipsis"
                   >
-                    {`${firstName} ${lastName}`}
+                    {designerName}
                   </Text>
                 </Flex>
               </Box>

--- a/src/interfaces/design.d.ts
+++ b/src/interfaces/design.d.ts
@@ -43,6 +43,7 @@ export interface ICourtColor {
 }
 
 export interface ISaveDesign {
+  designer?: string;
   user_id: string;
   designName: string;
   tileColor: ITileColor[];

--- a/src/interfaces/template.d.ts
+++ b/src/interfaces/template.d.ts
@@ -1,4 +1,4 @@
-import { IDesign } from "@/interfaces/design";
+import { ISaveDesign } from "@/interfaces/design";
 
 export interface ITags {
   CourtType: string;
@@ -9,7 +9,7 @@ export interface ITemplate {
   _id: string;
   user_id: string;
   description: string | undefined | null;
-  design: IDesign;
+  design: ISaveDesign;
   image: string;
   tags: ITags;
 }

--- a/src/utils/generateNewTemplate.ts
+++ b/src/utils/generateNewTemplate.ts
@@ -1,4 +1,4 @@
-import { IDesign } from "@/interfaces/design";
+import { ISaveDesign } from "@/interfaces/design";
 import { ITemplate } from "@/interfaces/template";
 import { CourtSizeState } from "@/store/reducer/courtSpecDataSlice";
 import { Court } from "@/store/reducer/tileSlice";
@@ -9,15 +9,17 @@ const generateNewTemplate = (
   name: string,
   description: string | undefined,
   selectedCourtTileData: Court[],
-  selectedCourt: CourtSizeState
+  selectedCourt: CourtSizeState,
+  imageUrl: string,
+  designer?: string
 ): ITemplate => {
   const courtSizeData = saveDesignMapping(selectedCourt);
   const tiles = selectedCourtTileData;
   const selectedCourtCategory = selectedCourt.courtName.replace(/ /g, "");
   const courtType = "basketball";
 
-  const newDesign: IDesign = {
-    _id: "",
+  const newDesign: ISaveDesign = {
+    designer: designer,
     user_id: "",
     designName: name,
     tileColor: tiles,
@@ -29,7 +31,7 @@ const generateNewTemplate = (
     user_id: userId,
     description,
     design: newDesign,
-    image: "image_url",
+    image: imageUrl,
     tags: {
       CourtCategory: selectedCourtCategory,
       CourtType: courtType,

--- a/src/utils/manageExternalImage.ts
+++ b/src/utils/manageExternalImage.ts
@@ -1,3 +1,9 @@
+export const generateImageFromDataUrl = async (courtDataUrl: string) => {
+  const base64 = await fetch(courtDataUrl);
+  const blob = await base64.blob();
+  return new File([blob], "default", { type: "image/png" });
+};
+
 export const upLoadScreenshot = async (courtDataUrl: string, toast: any) => {
   const { default: AWS } = await import(/* webpackChunkName: "aws-sdk" */ "aws-sdk");
   const { nanoid } = await import("nanoid");
@@ -7,10 +13,7 @@ export const upLoadScreenshot = async (courtDataUrl: string, toast: any) => {
   const IdentityPoolId = process.env.NEXT_PUBLIC_IDENTITY_POOL_ID as string;
   const albumName = process.env.NEXT_PUBLIC_ALBUM_NAME as string;
   const albumPhotosKey = encodeURIComponent(albumName) + "/";
-
-  const base64 = await fetch(courtDataUrl);
-  const blob = await base64.blob();
-  const imgFile = new File([blob], "default", { type: "image/png" });
+  const imgFile = await generateImageFromDataUrl(courtDataUrl);
 
   AWS.config.update({
     region: bucketRegion,


### PR DESCRIPTION
As the court screenshot feature has already been completed, the court preview image has been added to the create template page and image link can be stored in the database. 
<img width="753" alt="Screen Shot 2022-10-26 at 21 24 53" src="https://user-images.githubusercontent.com/86336676/198014375-86d42825-86ab-4061-b5eb-d068c5f5b53b.png">

