### PR TITLE
Feat/cc a1 image loading

### DIFF
--- a/src/__tests__/components/Folder/__snapshots__/FolderListItem.test.tsx.snap
+++ b/src/__tests__/components/Folder/__snapshots__/FolderListItem.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Render folder list Should render folder list item correctly 1`] = `
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+          style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain; filter: blur(20px); background-size: contain; background-image: url(https://cdn-images-1.medium.com/max/1800/1*sg-uLNm73whmdOgKlrQdZA.jpeg); background-position: 0% 0%;"
         />
         <noscript />
       </span>
@@ -154,7 +154,7 @@ exports[`Render folder list Should render opacity correctly 1`] = `
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+          style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain; filter: blur(20px); background-size: contain; background-image: url(https://cdn-images-1.medium.com/max/1800/1*sg-uLNm73whmdOgKlrQdZA.jpeg); background-position: 0% 0%;"
         />
         <noscript />
       </span>

--- a/src/components/FolderList/FolderListItem.tsx
+++ b/src/components/FolderList/FolderListItem.tsx
@@ -40,7 +40,14 @@ const FolderListItem = (props: any) => {
       </HStack>
       <Box width="80%" height="100%" position="relative">
         {image && image.startsWith("http") && (
-          <Image src={image.toString()} alt="Court image" layout="fill" objectFit="contain"></Image>
+          <Image
+            src={image.toString()}
+            alt="Court image"
+            layout="fill"
+            objectFit="contain"
+            placeholder="blur"
+            blurDataURL="https://cdn-images-1.medium.com/max/1800/1*sg-uLNm73whmdOgKlrQdZA.jpeg"
+          ></Image>
         )}
       </Box>
       <HStack spacing={8} style={{ margin: "4px" }}>

--- a/src/components/MyOrder/MyOrderItem.tsx
+++ b/src/components/MyOrder/MyOrderItem.tsx
@@ -15,6 +15,8 @@ const MyOrderItem = ({ ...mergedItem }) => {
               alt={`${mergedItem.design.designName} image`}
               layout="fill"
               objectFit="contain"
+              placeholder="blur"
+              blurDataURL="https://cdn-images-1.medium.com/max/1800/1*sg-uLNm73whmdOgKlrQdZA.jpeg"
             ></Image>
           </Box>
           <Stack direction="row">

--- a/src/components/MyTemplate/MyTemplateListItem.tsx
+++ b/src/components/MyTemplate/MyTemplateListItem.tsx
@@ -74,7 +74,14 @@ function MyTemplateListItem({ ...item }) {
         color="#000"
       >
         <Box width="80%" height="100%" position="relative">
-          <Image src={item.image} alt="Court image" layout="fill" objectFit="contain"></Image>
+          <Image
+            src={item.image}
+            alt="Court image"
+            layout="fill"
+            objectFit="contain"
+            placeholder="blur"
+            blurDataURL="https://cdn-images-1.medium.com/max/1800/1*sg-uLNm73whmdOgKlrQdZA.jpeg"
+          ></Image>
         </Box>
       </Flex>
       <Flex

--- a/src/components/OrderGeneration/OrderItem.tsx
+++ b/src/components/OrderGeneration/OrderItem.tsx
@@ -47,7 +47,14 @@ const OrderItem = ({ item, index, depositRatio }: IOrderProps) => {
           Design Preview
         </Text>
         <Box width="100%" height="217px" position="relative">
-          <Image src={image} alt="Court image" layout="fill" objectFit="contain" />
+          <Image
+            src={image}
+            alt="Court image"
+            layout="fill"
+            objectFit="contain"
+            placeholder="blur"
+            blurDataURL="https://cdn-images-1.medium.com/max/1800/1*sg-uLNm73whmdOgKlrQdZA.jpeg"
+          />
         </Box>
       </GridItem>
       <GridItem padding={{ base: "30px 14px", md: "30px 44px" }} borderBottom="2px solid #EBECF0">

--- a/src/components/TemplateList/TemplateItem.tsx
+++ b/src/components/TemplateList/TemplateItem.tsx
@@ -103,7 +103,13 @@ const TemplateItem = React.forwardRef<HTMLDivElement, Props>((prop, ref) => {
       </Box>
 
       <Box width="80%" height="full" position="relative" cursor="pointer" onClick={applyTemplate}>
-        <Image src={templateItem.courtImgUrl} layout="fill" objectFit="contain" />
+        <Image
+          src={templateItem.courtImgUrl}
+          layout="fill"
+          objectFit="contain"
+          placeholder="blur"
+          blurDataURL="https://cdn-images-1.medium.com/max/1800/1*sg-uLNm73whmdOgKlrQdZA.jpeg"
+        />
       </Box>
       <Flex width="full" wrap="wrap" gap="1rem" justifyContent="space-around">
         <CourtTags tags={templateItem.tags} />


### PR DESCRIPTION
Add loading stakeholder when image is loading

<img width="871" alt="Screenshot 2023-01-02 at 10 26 14 pm" src="https://user-images.githubusercontent.com/100055462/210228108-74789366-35ef-4649-8072-b73e02beb798.png">

the loading image will display in Template List, Quotation Page, My Template, My Order.
