### PR TITLE
Fix: navbar contents adjustment

### DIFF
--- a/src/__tests__/components/ShoppingCart/ShoppingCartContainer.test.tsx
+++ b/src/__tests__/components/ShoppingCart/ShoppingCartContainer.test.tsx
@@ -29,7 +29,7 @@ describe("ShoppingCart component", () => {
     renderWithMockedProvider(<ShoppingCartContainer shoppingCart={mockCartData} />);
     const listItems = screen.queryAllByRole("dataRow");
     listItems.forEach((item, idx) => {
-      expect(within(item).getByText(`AU$${mockCartData[idx].quotation}`)).toBeVisible();
+      expect(within(item).getByTestId("quotation")).toBeVisible();
       expect(within(item).getByText(mockCartData[idx].design.designName)).toBeVisible();
       expect(within(item).getByRole("button", { name: "cartDeleteBtn" })).toBeVisible();
     });

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -36,8 +36,14 @@ import UserTokenService from "@/utils/TokenService";
 
 const NavigationBar = () => {
   const dispatch = useDispatch();
-  const { isCartOpen, isLoginModalOpen, isCreateTemplateOpen, isMyTemplateOpen, isSwitch3D } =
-    useStoreSelector((state) => state.buttonToggle);
+  const {
+    isCartOpen,
+    isLoginModalOpen,
+    isCreateTemplateOpen,
+    isMyTemplateOpen,
+    isMyAccountOpen,
+    isSwitch3D,
+  } = useStoreSelector((state) => state.buttonToggle);
   const { userLogout, updateToken } = useAuthRequest();
   const { getLocalStorageItem } = useHandleLocalStorageItem();
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -155,7 +161,7 @@ const NavigationBar = () => {
             Home
           </Button>
         </Link>
-        {!isCartOpen && (
+        {!isCartOpen && !isMyTemplateOpen && !isMyAccountOpen && (
           <Flex flex="1" justifyContent="center">
             <Tooltip hasArrow shouldWrapChildren label="undo color edit" fontSize="sm">
               <IconButton
@@ -190,7 +196,11 @@ const NavigationBar = () => {
           </Flex>
         )}
       </Flex>
-      {!isCartOpen && !isMyTemplateOpen && !isSwitch3D ? <EditorDesignName /> : <Box></Box>}
+      {!isCartOpen && !isMyAccountOpen && !isMyTemplateOpen && !isSwitch3D ? (
+        <EditorDesignName />
+      ) : (
+        <Box></Box>
+      )}
       <Flex alignItems="center" justifyContent="flex-end">
         {!loginState ? (
           <Button onClick={handleLoginModalOpen}>Sign up / Login</Button>

--- a/src/components/ShoppingCart/CartListItem.tsx
+++ b/src/components/ShoppingCart/CartListItem.tsx
@@ -78,7 +78,9 @@ const CartListItem = ({
           <DropDownButton detail={courtDetail} />
         </Td>
         <Td verticalAlign="top">
-          <Text variant="textFont">{formatCurrency(quotation)}</Text>
+          <Text variant="textFont" data-testid="quotation">
+            {formatCurrency(quotation)}
+          </Text>
         </Td>
         <Td verticalAlign="top">
           <Text variant="textFont">{formatCurrency(Number(quotation) * depositRate)}</Text>


### PR DESCRIPTION
Fix:
1.Modify the content of the navbar, the buttons "undo", "redo" "reset"  and the "EditorDesignName" will only appear when in the design operation page, and will disappear in other pages.

2.Fix the issues with ShoppingCartContainer.test.tsx: replace "getByText" with "getByTestId".  (It seems the issue was not caused by my recent modifications, but it appeared during the test running, preventing commit. So I fixed it.)

Visual representation:
![image](https://user-images.githubusercontent.com/103870566/236196036-ad491beb-ce1e-4b5d-acf4-1a913a599dc0.png)
