### PR TITLE
Fix: Design folder court index mismatch, meaningless code to be removed

### DIFF
--- a/src/components/FullCourt/index.tsx
+++ b/src/components/FullCourt/index.tsx
@@ -35,7 +35,6 @@ const FullCourt = () => {
   const canvasStates = canvasControl.canvasStates;
 
   useEffect(() => {
-    console.log(canvasStates.selectedColor);
     ref.current.x(0);
     ref.current.y(0);
   }, [canvasStates.resetState]);

--- a/src/components/TopBar/SaveBoard.tsx
+++ b/src/components/TopBar/SaveBoard.tsx
@@ -59,7 +59,6 @@ const SaveBoard: React.FC = () => {
   }, [courtData]);
 
   useEffect(() => {
-    // setDesignName("test");
     if (designNames.includes(useDesignName)) {
       const index = designsData.findIndex((item) => item.designName === useDesignName);
       setCourtId(designsData[index]?.courtId);

--- a/src/components/TopBar/SaveBoard.tsx
+++ b/src/components/TopBar/SaveBoard.tsx
@@ -56,13 +56,19 @@ const SaveBoard: React.FC = () => {
 
   useEffect(() => {
     setDesignName(courtData.designName);
+  }, [courtData]);
+
+  useEffect(() => {
+    // setDesignName("test");
     if (designNames.includes(useDesignName)) {
       const index = designsData.findIndex((item) => item.designName === useDesignName);
+      console.log("designsData index: " + index);
+      console.log("courtId: " + courtData.courtId);
       setCourtId(designsData[index]?.courtId);
     } else {
       setCourtId(courtData.courtId);
     }
-  }, [designNames, courtData]);
+  }, [designNames, courtData, useDesignName]);
 
   useEffect(() => {
     const savedCourt = designsData.find((e) => e.courtId === courtData.courtId);

--- a/src/components/TopBar/SaveBoard.tsx
+++ b/src/components/TopBar/SaveBoard.tsx
@@ -62,8 +62,6 @@ const SaveBoard: React.FC = () => {
     // setDesignName("test");
     if (designNames.includes(useDesignName)) {
       const index = designsData.findIndex((item) => item.designName === useDesignName);
-      console.log("designsData index: " + index);
-      console.log("courtId: " + courtData.courtId);
       setCourtId(designsData[index]?.courtId);
     } else {
       setCourtId(courtData.courtId);

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -7,7 +7,6 @@ const Header = () => {
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="description" content="CourtCanva" />
-        <link rel="icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
The design in the folder did not match its index and courtId when users tried to save an updated design due to useState/setState async issue. useDesignName would not get updated in the current render as setDesignName is async. Alternatively, it would get the value of the last render. As a result, the index and courtId would alway be the ones user previously selected.  
Before fix:
https://www.loom.com/share/375cbcb28a5841d3b354015ccc9de4fc
After fix:
https://www.loom.com/share/46e504b40d7148c08ac0e75b6489207e

