### PR TITLE
Feature/cc 22 section layout on the right-hand side

### DIFF
--- a/src/__tests__/components/EditorRightSideBar/index.test.tsx
+++ b/src/__tests__/components/EditorRightSideBar/index.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from "@testing-library/react";
+import EditorRightSideBar from "@/components/EditorRightSideBar";
+import renderWithMockedProvider from "../../utils";
+
+describe("EditorRightSideBar component", () => {
+  test("Each box in the sidebar should render the correct text", () => {
+    renderWithMockedProvider(<EditorRightSideBar />);
+    const courtCanva1Text = screen.getByText("CourtCanva1");
+    const designToolsText = screen.getByText("Design Tools");
+    const displayAdjustmentText = screen.getByText("Display Adjustment");
+    const quotationText = screen.getByText("Quote");
+
+    expect(courtCanva1Text).toBeInTheDocument();
+    expect(designToolsText).toBeInTheDocument();
+    expect(displayAdjustmentText).toBeInTheDocument();
+    expect(quotationText).toBeInTheDocument();
+  });
+});

--- a/src/components/EditorFooter/index.tsx
+++ b/src/components/EditorFooter/index.tsx
@@ -48,11 +48,12 @@ const EditorFooter = () => {
       justifyContent="space-between"
       alignItems="center"
       px={4}
-      w="calc(100vw - 98px)"
+      w="calc(100vw - 298px)"
       bg="white"
       boxShadow="dark-lg"
       lineHeight="34px"
       left="98px"
+      right="200px"
       zIndex={1400}
     >
       <Box>

--- a/src/components/EditorRightSideBar/DesignTools.tsx
+++ b/src/components/EditorRightSideBar/DesignTools.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+
+const DesignTools = () => {
+  return <Box>Design Tools</Box>;
+};
+
+export default DesignTools;

--- a/src/components/EditorRightSideBar/DisplayAdjustment.tsx
+++ b/src/components/EditorRightSideBar/DisplayAdjustment.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+
+const DisplayAdjustment = () => {
+  return <Box>Display Adjustment</Box>;
+};
+
+export default DisplayAdjustment;

--- a/src/components/EditorRightSideBar/FileManagement.tsx
+++ b/src/components/EditorRightSideBar/FileManagement.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+
+const FileManagement = () => {
+  return <Box>CourtCanva1</Box>;
+};
+
+export default FileManagement;

--- a/src/components/EditorRightSideBar/Quotation.tsx
+++ b/src/components/EditorRightSideBar/Quotation.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+
+const Quotation = () => {
+  return <Box>Quote</Box>;
+};
+
+export default Quotation;

--- a/src/components/EditorRightSideBar/RightSideBarItemList.tsx
+++ b/src/components/EditorRightSideBar/RightSideBarItemList.tsx
@@ -1,0 +1,24 @@
+import DesignTools from "./DesignTools";
+import DisplayAdjustment from "./DisplayAdjustment";
+import FileManagement from "./FileManagement";
+import Quotation from "./Quotation";
+
+const rightSideBarItemList = [
+  {
+    id: 1,
+    section: <FileManagement />,
+  },
+  {
+    id: 2,
+    section: <DesignTools />,
+  },
+  {
+    id: 3,
+    section: <DisplayAdjustment />,
+  },
+  {
+    id: 4,
+    section: <Quotation />,
+  },
+];
+export default rightSideBarItemList;

--- a/src/components/EditorRightSideBar/index.tsx
+++ b/src/components/EditorRightSideBar/index.tsx
@@ -1,0 +1,28 @@
+import { Box, Flex } from "@chakra-ui/react";
+import React from "react";
+import rightSideBarItemList from "./RightSideBarItemList";
+
+const EditorRightSideBar = () => {
+  const itemNum = rightSideBarItemList.length;
+  return (
+    <Box bg="background.secondary" w="200px" h="100vh" position="fixed" top="72px" right="0">
+      <Flex flexDirection="column" maxW="200px" className="text-white" h="100%">
+        {rightSideBarItemList.map((item) => (
+          <React.Fragment key={item.id}>
+            <Flex
+              flex={item.id === itemNum ? 2 : 1}
+              h={`${100 / (itemNum + 1)}%`}
+              color="white"
+              p="16px 20px"
+            >
+              {item.section}
+            </Flex>
+            {item.id !== itemNum && <Box bg="white" h="1px" w="100%" />}
+          </React.Fragment>
+        ))}
+      </Flex>
+    </Box>
+  );
+};
+
+export default EditorRightSideBar;

--- a/src/components/PriceBar/index.tsx
+++ b/src/components/PriceBar/index.tsx
@@ -12,8 +12,8 @@ const PriceBar: React.FC = () => {
       backgroundColor="background.tertiary"
       position="fixed"
       bottom="42px"
-      right="0px"
-      width="calc(100% - 98px)"
+      right="200px"
+      width="calc(100% - 298px)"
       zIndex="1500"
     >
       <TileColorBoard setTotalPrice={setTotalPrice} />

--- a/src/components/ThreeDimensionalCourt/index.tsx
+++ b/src/components/ThreeDimensionalCourt/index.tsx
@@ -35,7 +35,7 @@ const ThreeDimensionalToggle = ({ width, height, children }: Props) => {
         width="100px"
         height="40px"
         position="absolute"
-        right="18px"
+        right="218px"
         top="38px"
         justifyContent="center"
         alignItems="center"

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -98,7 +98,7 @@ const TopBar = () => {
     <Grid
       gridTemplateColumns={{ base: "0 1fr 1fr", lg: "1fr 1fr 1fr" }}
       position="fixed"
-      width="calc(100vw - 98px)"
+      width="calc(100vw - 298px)"
       background="background.tertiary"
       left="98px"
       top="73px"

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -19,6 +19,7 @@ import {
 
 import OrderGeneration from "@/components/OrderGeneration";
 import MyAccount from "@/components/MyAccount";
+import EditorRightSideBar from "@/components/EditorRightSideBar";
 
 const Layout: React.FC<{ children: ReactNode }> = ({ children }) => {
   const router = useRouter();
@@ -84,6 +85,7 @@ const Layout: React.FC<{ children: ReactNode }> = ({ children }) => {
             <EditorSideBar />
             {children}
             <TopBar />
+            <EditorRightSideBar />
           </Box>
           <PriceBar />
           <EditorFooter />


### PR DESCRIPTION
Feature:
1.Create a dedicated section layout positioned on the right-hand side of the page.
2.The section layout is divided into four parts: courtCanva1, designTools, displayAdjustment, quotation. 

Visual representation:
<img width="1907" alt="image" src="https://github.com/courtcanva/cc-app/assets/103870566/0c14ead8-5053-4ac9-9794-f6d26e8d3425">
