### PR TITLE
Fix/cc 39 comment out  old code of design tools section

### DIFF
--- a/src/__tests__/components/TopBar/index.test.tsx
+++ b/src/__tests__/components/TopBar/index.test.tsx
@@ -16,10 +16,10 @@ describe("TopBar", () => {
     expect(borderWidthTextElement).toBeInTheDocument();
   });
 
-  it("should render color select button", () => {
-    renderWithMockedProvider(<TopBar />);
-    expect(screen.getByTestId("colorSelectBtn")).toBeTruthy();
-  });
+  // it("should render color select button", () => {
+  //   renderWithMockedProvider(<TopBar />);
+  //   expect(screen.getByTestId("colorSelectBtn")).toBeTruthy();
+  // });
 
   it("should render upload image btn", () => {
     renderWithMockedProvider(<TopBar />);

--- a/src/components/TopBar/index.tsx
+++ b/src/components/TopBar/index.tsx
@@ -108,7 +108,7 @@ const TopBar = () => {
         marginLeft="35px"
       >
         <Flex alignItems="center" gap="3" marginRight={{ base: "55px", lg: "50px", xl: "100px" }}>
-          <Tooltip hasArrow shouldWrapChildren label="Paint Bucket" fontSize="sm" placement="top">
+          {/* <Tooltip hasArrow shouldWrapChildren label="Paint Bucket" fontSize="sm" placement="top">
             <Popover
               isOpen={isPaintPopoverOpen}
               onOpen={open}
@@ -130,7 +130,7 @@ const TopBar = () => {
                 </PopoverBody>
               </PopoverContent>
             </Popover>
-          </Tooltip>
+          </Tooltip> */}
           <Tooltip hasArrow shouldWrapChildren label="Label Bucket" fontSize="sm" placement="top">
             <IconButton
               aria-label="Upload"


### PR DESCRIPTION
Fix: Comment out the old code of the "PaintBucket"

Visual representation:
<img width="1728" alt="image" src="https://github.com/courtcanva/cc-app/assets/103870566/c8482212-3293-41c3-abea-3a5fe1f2c715">