### PR TITLE
feat: add construction drawing for ui display

### DIFF
--- a/src/__tests__/components/EditorRightSideBar/Quotation.test.tsx
+++ b/src/__tests__/components/EditorRightSideBar/Quotation.test.tsx
@@ -125,3 +125,22 @@ describe("click add-to-cart button", () => {
     await waitFor(() => expect(mockAddToCart).toBeCalled());
   });
 });
+
+describe("click construction-on button", () => {
+  it("should switch construction mounted and construction open", async () => {
+    const mockSwitchConstructionMounted = jest.spyOn(
+      buttonToggleSlice,
+      "switchConstructionMounted"
+    );
+    renderWithMockedProvider(<Quotation />);
+    const constructionBtn = screen.getByText(/Construction On/i);
+    userEvent.click(constructionBtn);
+    await waitFor(
+      () => {
+        expect(upLoadScreenshot).toBeCalled();
+        expect(mockSwitchConstructionMounted).toBeCalled();
+      },
+      { timeout: 10000 }
+    );
+  });
+});

--- a/src/__tests__/redux/constructionSlice.test.ts
+++ b/src/__tests__/redux/constructionSlice.test.ts
@@ -1,0 +1,42 @@
+import store from "@/store/index";
+import reducer, {
+  initialState,
+  changeConstructionInfo,
+  changeConstructionSrc,
+  ConstructionState,
+} from "@/store/reducer/constructionSlice";
+
+const constructionInfo = {
+  beginPointX: 1,
+  beginPointY: 1,
+  endPointX: 1,
+  endPointY: 1,
+  tileSize: 1,
+};
+
+it("should return the initial state", () => {
+  const state = store.getState().construction;
+  expect(state).toEqual(initialState);
+});
+
+it("should render correct construction information", () => {
+  const previousState: ConstructionState = initialState;
+  expect(reducer(previousState, changeConstructionInfo(constructionInfo))).toEqual({
+    ...previousState,
+    constructionInfo: {
+      beginPointX: 1,
+      beginPointY: 1,
+      endPointX: 1,
+      endPointY: 1,
+      tileSize: 1,
+    },
+  });
+});
+
+it("should render correct construction source", () => {
+  const previousState: ConstructionState = initialState;
+  expect(reducer(previousState, changeConstructionSrc("mockSrc"))).toEqual({
+    ...previousState,
+    constructionSrc: "mockSrc",
+  });
+});

--- a/src/components/Construction/index.tsx
+++ b/src/components/Construction/index.tsx
@@ -1,0 +1,252 @@
+import { RIGHT_BAR_WIDTH } from "@/constants/designPage";
+import { Box, Center, Button } from "@chakra-ui/react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import Konva from "konva";
+import { useDispatch } from "react-redux";
+import { Stage, Layer, Line, Rect, Text, Image } from "react-konva";
+import { useStoreSelector } from "@/store/hooks";
+import { COORDINATES_AREA_WIDTH, IMAGE_COVERAGE, PIXEL_RATIO } from "@/constants/construction";
+import { switchConstructionMounted } from "@/store/reducer/buttonToggleSlice";
+
+interface Coordinates {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text: string;
+}
+
+const Construction = () => {
+  const dispatch = useDispatch();
+  const pdfRef = useRef<Konva.Stage>(null);
+  const imgSrc = useStoreSelector((state) => state.construction.constructionSrc);
+  const constructionInfo = useStoreSelector((state) => state.construction.constructionInfo);
+  const { beginPointX, beginPointY, endPointX, endPointY, tileSize } = constructionInfo;
+  const constructionRatio = window.innerHeight / (endPointY - beginPointY);
+  // calculate suitable font size for different design
+  const coordinateFontSize = Math.floor(3 * constructionRatio);
+  const constructionWidth = constructionRatio * (endPointX - beginPointX);
+  const constructionHeight = constructionRatio * (endPointY - beginPointY);
+  const canvasWidth =
+    constructionWidth * IMAGE_COVERAGE +
+    COORDINATES_AREA_WIDTH +
+    tileSize * constructionRatio * IMAGE_COVERAGE;
+  const canvasHeight =
+    constructionHeight * IMAGE_COVERAGE +
+    COORDINATES_AREA_WIDTH +
+    tileSize * constructionRatio * IMAGE_COVERAGE;
+
+  const [img, setImg] = useState(new window.Image());
+  useEffect(() => {
+    if (imgSrc) {
+      const loadImg = new window.Image();
+      loadImg.onload = () => {
+        setImg(loadImg);
+      };
+      loadImg.src = imgSrc;
+    }
+  }, []);
+
+  // prepare start and end points of lines along the x axis
+  const xLineLength =
+    Math.ceil(constructionHeight / (tileSize * constructionRatio) - 0.001) *
+    (tileSize * constructionRatio) *
+    IMAGE_COVERAGE;
+
+  const xLinesPoints = useMemo(() => {
+    return Array.from(
+      { length: Math.ceil((endPointX - beginPointX) / tileSize) + 1 },
+      (v, k) => k
+    ).map((number) => {
+      const x = number * tileSize * constructionRatio * IMAGE_COVERAGE + COORDINATES_AREA_WIDTH;
+      return [x, COORDINATES_AREA_WIDTH, x, COORDINATES_AREA_WIDTH + xLineLength];
+    });
+  }, []);
+
+  // prepare start and end points of lines along the y axis
+  const yLineLength =
+    Math.ceil(constructionWidth / (tileSize * constructionRatio) - 0.001) *
+    (tileSize * constructionRatio) *
+    IMAGE_COVERAGE;
+
+  const yLinesPoints = useMemo(() => {
+    return Array.from(
+      { length: Math.ceil((endPointY - beginPointY) / tileSize) + 1 },
+      (v, k) => k
+    ).map((number) => {
+      const y = number * tileSize * constructionRatio * IMAGE_COVERAGE + COORDINATES_AREA_WIDTH;
+      return [COORDINATES_AREA_WIDTH, y, COORDINATES_AREA_WIDTH + yLineLength, y];
+    });
+  }, []);
+
+  const xCoordinates = useMemo(() => {
+    return xLinesPoints
+      .map((item, index) => {
+        return {
+          x: item[0],
+          y: 0,
+          width: tileSize * constructionRatio * IMAGE_COVERAGE,
+          height: COORDINATES_AREA_WIDTH,
+          text:
+            Math.floor(index / 100).toString() +
+            Math.floor((index % 100) / 10).toString() +
+            (index % 10).toString(),
+        };
+      })
+      .slice(0, -1);
+  }, []);
+
+  const yCoordinates = useMemo(() => {
+    return yLinesPoints
+      .map((item, index) => {
+        return {
+          x: 0,
+          y: item[1],
+          width: COORDINATES_AREA_WIDTH,
+          height: tileSize * constructionRatio * IMAGE_COVERAGE,
+          text:
+            String.fromCharCode(65 + Math.floor(index / 26)) +
+            String.fromCharCode(65 + (index % 26)),
+        };
+      })
+      .slice(0, -1);
+  }, []);
+
+  const getCartesianCoordinates = useCallback(
+    (xCoordinates: Coordinates[], yCoordinates: Coordinates[]) => {
+      const cartesianCoordinates: Coordinates[] = [];
+      xCoordinates.forEach((xCoordinate) => {
+        yCoordinates.forEach((yCoordinate) => {
+          const cartesianCoordinate = {
+            x: xCoordinate.x,
+            y: yCoordinate.y,
+            width: tileSize * constructionRatio * IMAGE_COVERAGE,
+            height: tileSize * constructionRatio * IMAGE_COVERAGE,
+            text: xCoordinate.text + "\n" + yCoordinate.text,
+          };
+          cartesianCoordinates.push(cartesianCoordinate);
+        });
+      });
+      return cartesianCoordinates;
+    },
+    []
+  );
+
+  const cartesianCoordinates = useMemo(() => {
+    return getCartesianCoordinates(xCoordinates, yCoordinates);
+  }, []);
+
+  // extract the position of original construction button
+  const constructionButton = document.getElementById("constructionButton");
+  const rect = constructionButton?.getBoundingClientRect();
+
+  const handleConstructionClose = useCallback(() => {
+    dispatch(switchConstructionMounted(false));
+  }, []);
+
+  return (
+    <Box position="fixed" h="100vh" w="100vw" bottom="0" left="0" bg="blackAlpha.600" zIndex="5999">
+      <Center h="100vh" w={`calc(100vw - ${RIGHT_BAR_WIDTH})`}>
+        <Stage width={canvasWidth} height={canvasHeight} ref={pdfRef}>
+          <Layer>
+            <Rect x={0} y={0} width={canvasWidth} height={canvasHeight} fill="white" />
+            {xCoordinates.map((item, index) => {
+              return (
+                <Text
+                  key={index}
+                  x={item.x}
+                  y={item.y}
+                  width={item.width}
+                  height={item.height}
+                  text={item.text}
+                  align="center"
+                  fontSize={10}
+                  verticalAlign="middle"
+                />
+              );
+            })}
+            {yCoordinates.map((item, index) => {
+              return (
+                <Text
+                  key={index}
+                  x={item.x}
+                  y={item.y}
+                  width={item.width}
+                  height={item.height}
+                  text={item.text}
+                  align="center"
+                  verticalAlign="middle"
+                />
+              );
+            })}
+          </Layer>
+          <Layer>
+            <Image
+              x={COORDINATES_AREA_WIDTH}
+              y={COORDINATES_AREA_WIDTH}
+              image={img}
+              width={(img.width * constructionRatio * IMAGE_COVERAGE) / PIXEL_RATIO}
+              height={(img.height * constructionRatio * IMAGE_COVERAGE) / PIXEL_RATIO}
+            />
+          </Layer>
+          <Layer>
+            {xLinesPoints.map((linePoints, index) => {
+              return (
+                <Line
+                  key={index}
+                  points={linePoints}
+                  stroke="#000000"
+                  strokeWidth={1}
+                  opacity={0.5}
+                />
+              );
+            })}
+            {yLinesPoints.map((linePoints, index) => {
+              return (
+                <Line
+                  key={index}
+                  points={linePoints}
+                  stroke="#000000"
+                  strokeWidth={1}
+                  opacity={0.5}
+                />
+              );
+            })}
+            {cartesianCoordinates.map((item, index) => {
+              return (
+                <Text
+                  key={index}
+                  x={item.x}
+                  y={item.y}
+                  width={item.width}
+                  height={item.height}
+                  text={item.text}
+                  align="center"
+                  verticalAlign="middle"
+                  fontSize={coordinateFontSize}
+                />
+              );
+            })}
+          </Layer>
+        </Stage>
+      </Center>
+      {rect && (
+        <Button
+          variant="solid"
+          w="160px"
+          bg="black"
+          color="white"
+          onClick={handleConstructionClose}
+          position="fixed"
+          zIndex="5999"
+          top={rect.top}
+          left={rect.left}
+        >
+          Construction Off
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export default Construction;

--- a/src/components/EditorRightSideBar/DisplayAdjustment/index.tsx
+++ b/src/components/EditorRightSideBar/DisplayAdjustment/index.tsx
@@ -17,10 +17,12 @@ import { switchRuler } from "@/store/reducer/buttonToggleSlice";
 import { useStoreSelector } from "@/store/hooks";
 import { changeZoomScale, dragSwitch, resetAll } from "@/store/reducer/canvasControlSlice";
 import { MAX_ZOOM, MIN_ZOOM } from "@/constants/zoomLimit";
+import { useRef } from "react";
 
 const DisplayAdjustment = () => {
   const { zoomScale } = useStoreSelector((state) => state.canvasControl);
-
+  const rulerRef = useRef<HTMLInputElement>(null);
+  const isRulerOn = useStoreSelector((state) => state.buttonToggle.isRulerOn);
   const dispatch = useDispatch();
   const handleRulerState = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(switchRuler(e.target.checked));
@@ -121,6 +123,8 @@ const DisplayAdjustment = () => {
             defaultChecked
             data-testid="switch-btn"
             onChange={handleRulerState}
+            ref={rulerRef}
+            isChecked={isRulerOn}
           />
         </FormControl>
       </Flex>

--- a/src/components/EditorRightSideBar/Quotation/index.tsx
+++ b/src/components/EditorRightSideBar/Quotation/index.tsx
@@ -7,7 +7,11 @@ import { ICartItem } from "@/interfaces/cartItem";
 import { saveDesignMapping } from "@/utils/designMapping";
 import { IDesign, ITileColor } from "@/interfaces/design";
 import { useDispatch } from "react-redux";
-import { switchLoginModal } from "@/store/reducer/buttonToggleSlice";
+import {
+  switchLoginModal,
+  switchConstructionMounted,
+  switchRuler,
+} from "@/store/reducer/buttonToggleSlice";
 import { upLoadScreenshot } from "@/utils/manageExternalImage";
 import { COURT_TYPE } from "@/constants/courtData";
 import { useGetDepositQuery } from "@/redux/api/depositApi";
@@ -15,6 +19,7 @@ import priceFormat from "@/utils/priceFormat";
 import { useGetPriceQuery } from "@/redux/api/priceApi";
 import { calculateQuotation, calculateDeposit } from "@/utils/priceCalculation";
 import { TilePrices } from "@/interfaces/priceCalculation";
+import { resetAll } from "@/store/reducer/canvasControlSlice";
 import formatCurrency from "@/utils/formatCurrency";
 
 const Quotation = () => {
@@ -83,6 +88,14 @@ const Quotation = () => {
     });
   };
 
+  const handleConstructionOpen = () => {
+    dispatch(resetAll());
+    dispatch(switchRuler(false));
+    setTimeout(() => {
+      dispatch(switchConstructionMounted(true));
+    });
+  };
+
   return (
     <Box>
       <Text fontSize="14px" fontWeight="700" mb="10px">
@@ -103,6 +116,18 @@ const Quotation = () => {
       </Flex>
       <Button variant="shareBtn" w="160px" mt="12px" onClick={handleAddToCart}>
         Add to Cart
+      </Button>
+      <Button
+        variant="outline"
+        color="black"
+        w="160px"
+        mt="12px"
+        onClick={handleConstructionOpen}
+        position="relative"
+        id="constructionButton"
+        borderColor="black"
+      >
+        Construction On
       </Button>
     </Box>
   );

--- a/src/components/FullCourt/index.tsx
+++ b/src/components/FullCourt/index.tsx
@@ -17,10 +17,18 @@ import canvasControlModel from "../../utils/canvasControlModel";
 import useImageDataUrl from "@/hooks/useImageDataUrl";
 import ThreeDimensionalToggle from "../ThreeDimensionalCourt";
 import { useTileCalculation } from "@/hooks/useTileCalculation";
+import { useConstruction } from "@/hooks/useConstruction";
 import { RIGHT_BAR_WIDTH } from "@/constants/designPage";
 
 const FullCourt = () => {
-  const { courtAreaXLength, courtAreaYLength, borderLength, court, courtStartPoint } = useCourt();
+  const {
+    courtAreaXLength,
+    courtAreaYLength,
+    borderLength,
+    court,
+    courtStartPoint,
+    courtAndTileInfo,
+  } = useCourt();
   const stageRef = useRef<any>(null);
   const layerRef = useRef<any>(null);
 
@@ -44,6 +52,7 @@ const FullCourt = () => {
 
   useImageDataUrl(stageRef);
   useTileCalculation(layerRef);
+  useConstruction(layerRef, courtAndTileInfo);
 
   return (
     <Flex

--- a/src/components/HalfCourt/index.tsx
+++ b/src/components/HalfCourt/index.tsx
@@ -16,10 +16,18 @@ import canvasControlModel from "../../utils/canvasControlModel";
 import useImageDataUrl from "@/hooks/useImageDataUrl";
 import ThreeDimensionalToggle from "../ThreeDimensionalCourt";
 import { useTileCalculation } from "@/hooks/useTileCalculation";
+import { useConstruction } from "@/hooks/useConstruction";
 import { RIGHT_BAR_WIDTH } from "@/constants/designPage";
 
 const HalfCourt = () => {
-  const { courtAreaXLength, courtAreaYLength, borderLength, court, courtStartPoint } = useCourt();
+  const {
+    courtAreaXLength,
+    courtAreaYLength,
+    borderLength,
+    court,
+    courtStartPoint,
+    courtAndTileInfo,
+  } = useCourt();
   const stageRef = useRef<any>(null);
   const layerRef = useRef<any>(null);
 
@@ -43,6 +51,7 @@ const HalfCourt = () => {
 
   useImageDataUrl(stageRef);
   useTileCalculation(layerRef);
+  useConstruction(layerRef, courtAndTileInfo);
 
   return (
     <Flex

--- a/src/components/MediumCourt/index.tsx
+++ b/src/components/MediumCourt/index.tsx
@@ -16,6 +16,7 @@ import canvasControlModel from "../../utils/canvasControlModel";
 import useImageDataUrl from "@/hooks/useImageDataUrl";
 import ThreeDimensionalToggle from "../ThreeDimensionalCourt";
 import { useTileCalculation } from "@/hooks/useTileCalculation";
+import { useConstruction } from "@/hooks/useConstruction";
 import { RIGHT_BAR_WIDTH } from "@/constants/designPage";
 
 const MediumCourt = () => {
@@ -27,6 +28,7 @@ const MediumCourt = () => {
     stageMargin,
     courtStartPoint,
     componentsStartPoint,
+    courtAndTileInfo,
   } = useCourt();
 
   const stageRef = useRef<any>(null);
@@ -52,6 +54,7 @@ const MediumCourt = () => {
 
   useImageDataUrl(stageRef);
   useTileCalculation(layerRef);
+  useConstruction(layerRef, courtAndTileInfo);
 
   return (
     <Flex

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -118,7 +118,7 @@ const NavigationBar = () => {
       minW="768px"
       w="100vw"
       position="fixed"
-      zIndex={9999}
+      zIndex={4999}
     >
       <Flex alignItems="center">
         <Link href={HOME_PAGE_LINK} passHref>

--- a/src/components/ProFullCourt/index.tsx
+++ b/src/components/ProFullCourt/index.tsx
@@ -17,10 +17,18 @@ import canvasControlModel from "../../utils/canvasControlModel";
 import useImageDataUrl from "@/hooks/useImageDataUrl";
 import { useTileCalculation } from "@/hooks/useTileCalculation";
 import ThreeDimensionalToggle from "@/components/ThreeDimensionalCourt";
+import { useConstruction } from "@/hooks/useConstruction";
 import { RIGHT_BAR_WIDTH } from "@/constants/designPage";
 
 const ProFullCourt = () => {
-  const { courtAreaXLength, courtAreaYLength, borderLength, court, courtStartPoint } = useCourt();
+  const {
+    courtAreaXLength,
+    courtAreaYLength,
+    borderLength,
+    court,
+    courtStartPoint,
+    courtAndTileInfo,
+  } = useCourt();
   const stageRef = useRef<any>(null);
   const layerRef = useRef<any>(null);
 
@@ -44,6 +52,7 @@ const ProFullCourt = () => {
 
   useImageDataUrl(stageRef);
   useTileCalculation(layerRef);
+  useConstruction(layerRef, courtAndTileInfo);
 
   return (
     <Flex

--- a/src/components/ProHalfCourt/index.tsx
+++ b/src/components/ProHalfCourt/index.tsx
@@ -23,6 +23,7 @@ import { calculation } from "@/utils/tileNumberCalculator";
 import { changeTileQuantity, PriceBar } from "@/store/reducer/priceBarSlice";
 import { useStoreSelector } from "@/store/hooks";
 import ThreeDimensionalToggle from "../ThreeDimensionalCourt";
+import { useConstruction } from "@/hooks/useConstruction";
 import { RIGHT_BAR_WIDTH } from "@/constants/designPage";
 
 const ProHalfCourt = () => {
@@ -92,6 +93,7 @@ const ProHalfCourt = () => {
   }, [canvasStates.resetState]);
 
   useImageDataUrl(ref);
+  useConstruction(reference, clipLength === 0 && clipWidth === 0 ? courtAndTileInfo : tileInfo);
 
   return (
     <Flex

--- a/src/components/SmallCourt/index.tsx
+++ b/src/components/SmallCourt/index.tsx
@@ -17,6 +17,7 @@ import canvasControlModel from "../../utils/canvasControlModel";
 import useImageDataUrl from "@/hooks/useImageDataUrl";
 import ThreeDimensionalToggle from "../ThreeDimensionalCourt";
 import { useTileCalculation } from "@/hooks/useTileCalculation";
+import { useConstruction } from "@/hooks/useConstruction";
 import { RIGHT_BAR_WIDTH } from "@/constants/designPage";
 
 const SmallCourt = () => {
@@ -28,6 +29,7 @@ const SmallCourt = () => {
     stageMargin,
     courtStartPoint,
     componentsStartPoint,
+    courtAndTileInfo,
   } = useCourt();
   const stageRef = useRef<any>(null);
   const layerRef = useRef<any>(null);
@@ -52,6 +54,7 @@ const SmallCourt = () => {
 
   useImageDataUrl(stageRef);
   useTileCalculation(layerRef);
+  useConstruction(layerRef, courtAndTileInfo);
 
   return (
     <Flex

--- a/src/constants/construction.ts
+++ b/src/constants/construction.ts
@@ -1,0 +1,4 @@
+export const IMAGE_COVERAGE = 0.93;
+export const COORDINATES_AREA_WIDTH = 25;
+export const DRAW_DELAY = 2500;
+export const PIXEL_RATIO = 2;

--- a/src/hooks/useConstruction.ts
+++ b/src/hooks/useConstruction.ts
@@ -1,0 +1,33 @@
+import Konva from "konva";
+import { RefObject, useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { changeConstructionSrc, changeConstructionInfo } from "@/store/reducer/constructionSlice";
+import { PIXEL_RATIO } from "@/constants/construction";
+import { ConstructionInfo } from "@/store/reducer/constructionSlice";
+
+export const useConstruction = (
+  canvasRef: RefObject<Konva.Layer>,
+  constructionInfo: ConstructionInfo
+) => {
+  const dispatch = useDispatch();
+  const canvas = canvasRef.current;
+  let { beginPointX, beginPointY } = { ...constructionInfo };
+  useEffect(() => {
+    if (!canvas) return;
+    const drawRatioX = canvas.getCanvas()._canvas.width / canvas.getWidth();
+    const drawRatioY = canvas.getCanvas()._canvas.height / canvas.getHeight();
+    beginPointX *= drawRatioX;
+    beginPointY *= drawRatioY;
+    const canvasWidth = canvas.getCanvas()._canvas.width;
+    const canvasHeight = canvas.getCanvas()._canvas.height;
+    const dataUrl = canvas.toDataURL({
+      x: beginPointX,
+      y: beginPointY,
+      width: canvasWidth,
+      height: canvasHeight,
+      pixelRatio: PIXEL_RATIO,
+    });
+    dispatch(changeConstructionSrc(dataUrl));
+    dispatch(changeConstructionInfo(constructionInfo));
+  }, [constructionInfo]);
+};

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,21 +1,25 @@
 import { ReactNode } from "react";
 import { Box } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import { useStoreSelector } from "@/store/hooks";
 import Header from "./Header";
 import NavigationBar from "../components/NavBar";
 import EditorSideBar from "../components/EditorSideBar";
 import ShoppingCart from "@/components/ShoppingCart";
 import MyTemplate from "@/components/MyTemplate";
 import { PAGE_NOT_FOUND, PAYMENT, MY_ORDER } from "../../src/constants";
-
+import dynamic from "next/dynamic";
 import OrderGeneration from "@/components/OrderGeneration";
 import MyAccount from "@/components/MyAccount";
 import EditorRightSideBar from "@/components/EditorRightSideBar";
 import TileBoard from "@/components/TileBoard";
 
+const Construction = dynamic(() => import("@/components/Construction"), { ssr: false });
 const Layout: React.FC<{ children: ReactNode }> = ({ children }) => {
   const router = useRouter();
-
+  const isConstructionMounted = useStoreSelector(
+    (state) => state.buttonToggle.isConstructionMounted
+  );
   switch (router.pathname) {
     case PAGE_NOT_FOUND:
       return (
@@ -61,6 +65,7 @@ const Layout: React.FC<{ children: ReactNode }> = ({ children }) => {
             <EditorSideBar />
             {children}
             <EditorRightSideBar />
+            {isConstructionMounted && <Construction />}
           </Box>
           <TileBoard />
         </>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,6 +18,7 @@ import { templateApi } from "@/redux/api/templateApi";
 import orderReducer from "./reducer/orderSlice";
 import { orderApi } from "@/redux/api/orderApi";
 import { depositApi } from "../redux/api/depositApi";
+import constructionReducer from "./reducer/constructionSlice";
 
 export const makeStore = () =>
   configureStore({
@@ -41,6 +42,7 @@ export const makeStore = () =>
       colorList: colorListReducer,
       canvasControl: canvasControlReducer,
       order: orderReducer,
+      construction: constructionReducer,
     },
 
     middleware: (getDefaultMiddleware) =>

--- a/src/store/reducer/buttonToggleSlice.ts
+++ b/src/store/reducer/buttonToggleSlice.ts
@@ -13,6 +13,7 @@ export interface ButtonToggleState {
   isMyTemplateOpen: boolean;
   isSwitch3D: boolean;
   isMyAccountOpen: boolean;
+  isConstructionMounted: boolean;
 }
 
 export const initialState: ButtonToggleState = {
@@ -28,6 +29,7 @@ export const initialState: ButtonToggleState = {
   isMyTemplateOpen: false,
   isSwitch3D: false,
   isMyAccountOpen: false,
+  isConstructionMounted: false,
 };
 
 export const ButtonToggleSlice = createSlice({
@@ -149,6 +151,12 @@ export const ButtonToggleSlice = createSlice({
         isCreateTemplateOpen: false,
       };
     },
+    switchConstructionMounted: (state: ButtonToggleState, action: PayloadAction<boolean>) => {
+      return {
+        ...state,
+        isConstructionMounted: action.payload,
+      };
+    },
   },
 });
 
@@ -166,6 +174,7 @@ export const {
   switchOrderGeneration,
   switch3D,
   switchMyAccount,
+  switchConstructionMounted,
 } = ButtonToggleSlice.actions;
 
 export default ButtonToggleSlice.reducer;

--- a/src/store/reducer/constructionSlice.ts
+++ b/src/store/reducer/constructionSlice.ts
@@ -1,0 +1,49 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+export interface ConstructionState {
+  constructionSrc: string | null;
+  constructionPdfSrc: string | null;
+  constructionInfo: ConstructionInfo;
+}
+
+export interface ConstructionInfo {
+  beginPointX: number;
+  beginPointY: number;
+  endPointX: number;
+  endPointY: number;
+  tileSize: number;
+}
+
+export const initialState: ConstructionState = {
+  constructionSrc: null,
+  constructionPdfSrc: null,
+  constructionInfo: {
+    beginPointX: 0,
+    beginPointY: 0,
+    endPointX: 0,
+    endPointY: 0,
+    tileSize: 0,
+  },
+};
+
+export const ConstructionSlice = createSlice({
+  name: "Construction",
+  initialState,
+  reducers: {
+    changeConstructionSrc: (state: ConstructionState, action: PayloadAction<string>) => {
+      return {
+        ...state,
+        constructionSrc: action.payload,
+      };
+    },
+    changeConstructionInfo: (state: ConstructionState, action: PayloadAction<ConstructionInfo>) => {
+      return {
+        ...state,
+        constructionInfo: action.payload,
+      };
+    },
+  },
+});
+
+export const { changeConstructionSrc, changeConstructionInfo } = ConstructionSlice.actions;
+
+export default ConstructionSlice.reducer;


### PR DESCRIPTION
1. Add construction drawing on design page and buttons in right-side editor bar to turn on/off the construction drawing.
![image](https://github.com/courtcanva/cc-app/assets/121526486/9ca4455e-89a5-4104-926d-3eb5f714b7a1)
2. Add x, y coordinates on the border and cartesian coordinates on each tile as the unique id.
![image](https://github.com/courtcanva/cc-app/assets/121526486/016904c0-accc-4134-b1e5-61b968830648)
