### PR TITLE
fix: resolve construction drawing display issue

### DIFF
--- a/src/hooks/useConstruction.ts
+++ b/src/hooks/useConstruction.ts
@@ -11,20 +11,14 @@ export const useConstruction = (
 ) => {
   const dispatch = useDispatch();
   const canvas = canvasRef.current;
-  let { beginPointX, beginPointY } = { ...constructionInfo };
+  const { beginPointX, beginPointY, endPointX, endPointY } = { ...constructionInfo };
   useEffect(() => {
     if (!canvas) return;
-    const drawRatioX = canvas.getCanvas()._canvas.width / canvas.getWidth();
-    const drawRatioY = canvas.getCanvas()._canvas.height / canvas.getHeight();
-    beginPointX *= drawRatioX;
-    beginPointY *= drawRatioY;
-    const canvasWidth = canvas.getCanvas()._canvas.width;
-    const canvasHeight = canvas.getCanvas()._canvas.height;
     const dataUrl = canvas.toDataURL({
       x: beginPointX,
       y: beginPointY,
-      width: canvasWidth,
-      height: canvasHeight,
+      width: endPointX - beginPointX,
+      height: endPointY - beginPointY,
       pixelRatio: PIXEL_RATIO,
     });
     dispatch(changeConstructionSrc(dataUrl));


### PR DESCRIPTION
Conctruction drawing is displayed incorrecly in uat/prod
before:
![image](https://github.com/courtcanva/cc-app/assets/121526486/c62c5a8a-4c10-4771-9efc-d71b550d9dbe)
after:
![image](https://github.com/courtcanva/cc-app/assets/121526486/f0064c6d-2d99-462c-9711-e6b90afc89e3)
