### PR TITLE
Feat/cc72 save badge image to s3 and load from folder

### DIFF
--- a/src/__tests__/components/Folder/__snapshots__/FolderListItem.test.tsx.snap
+++ b/src/__tests__/components/Folder/__snapshots__/FolderListItem.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Render folder list Should render folder list item correctly 1`] = `
       </button>
     </div>
     <div
-      class="css-r0om48"
+      class="css-1dus09t"
     >
       <span
         style="box-sizing: border-box; display: block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px;"
@@ -144,7 +144,7 @@ exports[`Render folder list Should render opacity correctly 1`] = `
       </button>
     </div>
     <div
-      class="css-r0om48"
+      class="css-1dus09t"
     >
       <span
         style="box-sizing: border-box; display: block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px;"

--- a/src/__tests__/redux/badgeSlice.test.ts
+++ b/src/__tests__/redux/badgeSlice.test.ts
@@ -1,4 +1,9 @@
-import reducer, { initialState, switchBadgeUsed, setBadgeImage } from "@/store/reducer/badgeSlice";
+import reducer, {
+  initialState,
+  switchBadgeUsed,
+  setBadgeImage,
+  resetBadgeImage,
+} from "@/store/reducer/badgeSlice";
 
 describe("Badge Reducer", () => {
   it("should switch badge used state", () => {
@@ -14,5 +19,8 @@ describe("Badge Reducer", () => {
       ...initialState,
       badgeImage: newBadge,
     });
+  });
+  it("should switch to initial state", () => {
+    expect(reducer(initialState, resetBadgeImage())).toEqual(initialState);
   });
 });

--- a/src/__tests__/utils/designMapping.test.ts
+++ b/src/__tests__/utils/designMapping.test.ts
@@ -30,6 +30,11 @@ it("should return mapped data", () => {
     updatedAt: "2022-04-12T11:02:58.964+0000",
     isDeleted: false,
     image: "",
+    badgeImage: {
+      badgeImageUrl: "badgeImage-url",
+      width: 90,
+      height: 90,
+    }
   };
 
   const { mappedDesignsData, mappedTileData } = designMapping([design]);

--- a/src/__tests__/utils/designMapping.test.ts
+++ b/src/__tests__/utils/designMapping.test.ts
@@ -34,7 +34,7 @@ it("should return mapped data", () => {
       badgeImageUrl: "badgeImage-url",
       width: 90,
       height: 90,
-    }
+    },
   };
 
   const { mappedDesignsData, mappedTileData } = designMapping([design]);

--- a/src/__tests__/utils/generateNewTemplate.test.ts
+++ b/src/__tests__/utils/generateNewTemplate.test.ts
@@ -30,6 +30,11 @@ describe("generateNewTemplate", () => {
           image: "",
         },
         image: "",
+        badgeImage: {
+          badgeImageUrl: null,
+          width: 0,
+          height: 0,
+        },
       },
       image: "image_url",
       tags: {

--- a/src/components/BasketballCourt/CircleAreaWithBadge.tsx
+++ b/src/components/BasketballCourt/CircleAreaWithBadge.tsx
@@ -32,6 +32,7 @@ const CircleArea: React.FC<CircleAreaProps> = ({ startPoint }) => {
     setImage(loadingImg);
   };
   if (badgeImage.badgeImageUrl) {
+    loadingImg.crossOrigin = "Anonymous";
     loadingImg.src = badgeImage.badgeImageUrl;
   }
 

--- a/src/components/EditorRightSideBar/FileManagement/SaveBoard.tsx
+++ b/src/components/EditorRightSideBar/FileManagement/SaveBoard.tsx
@@ -42,6 +42,7 @@ const SaveBoard: React.FC = () => {
   const [useFeedback, setFeedback] = useState("");
   const [useSaveDesignModal, setSaveDesignModal] = useState(false);
   const courtDataUrl = useStoreSelector((state) => state.canvasControl.courtDataUrl);
+  const badgeImage = useStoreSelector((state) => state.badge.badgeImage);
   const { designTileList } = useStoreSelector((state) => state.designTileList);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -111,7 +112,14 @@ const SaveBoard: React.FC = () => {
           isClosable: true,
         });
       }
-      await addDesign({ design: { ...designData, image: courtDataUrl, courtType: COURT_TYPE } })
+      await addDesign({
+        design: {
+          ...designData,
+          image: courtDataUrl,
+          badgeImage: badgeImage,
+          courtType: COURT_TYPE,
+        },
+      })
         .unwrap()
         .then(() => {
           setFeedback("Your design has been saved.");
@@ -133,7 +141,12 @@ const SaveBoard: React.FC = () => {
       }
       await updateDesign({
         _id: useCourtId,
-        design: { ...designData, image: courtDataUrl, courtType: COURT_TYPE },
+        design: {
+          ...designData,
+          image: courtDataUrl,
+          badgeImage: badgeImage,
+          courtType: COURT_TYPE,
+        },
       })
         .unwrap()
         .then(() => {
@@ -179,7 +192,14 @@ const SaveBoard: React.FC = () => {
         isClosable: true,
       });
     }
-    await addDesign({ design: { ...designData, image: courtDataUrl, courtType: COURT_TYPE } })
+    await addDesign({
+      design: {
+        ...designData,
+        image: courtDataUrl,
+        badgeImage: badgeImage,
+        courtType: COURT_TYPE,
+      },
+    })
       .unwrap()
       .then(() => {
         setFeedback("Your design has been saved.");

--- a/src/components/EditorSideBar/Folder.tsx
+++ b/src/components/EditorSideBar/Folder.tsx
@@ -6,6 +6,7 @@ import { useStoreSelector } from "@/store/hooks";
 import { changeWholeCourtColor } from "@/store/reducer/tileSlice";
 import { ActionCreators } from "redux-undo";
 import FolderListItem from "../FolderList/FolderListItem";
+import { resetBadgeImage, setBadgeImage } from "@/store/reducer/badgeSlice";
 
 const Folder: React.FC = () => {
   const dispatch = useDispatch();
@@ -25,6 +26,12 @@ const Folder: React.FC = () => {
     const selectedDesignColor = designTileList.find((item) => item.courtId === courtId);
     if (selectedDesignColor === undefined) return;
     dispatch(changeWholeCourtColor(selectedDesignColor.tileColor));
+    const selectedDesignData = designsData.find((item) => item.courtId === courtId);
+    if (selectedDesignData?.badgeImage?.badgeImageUrl) {
+      dispatch(setBadgeImage(selectedDesignData.badgeImage));
+    } else {
+      dispatch(resetBadgeImage());
+    }
     dispatch(ActionCreators.clearHistory());
   };
   const folderEmpty = designsData?.length === 0;

--- a/src/components/FolderList/FolderListItem.tsx
+++ b/src/components/FolderList/FolderListItem.tsx
@@ -38,7 +38,7 @@ const FolderListItem = (props: any) => {
           <FolderDeleteModal />
         </IconButton>
       </HStack>
-      <Box width="80%" height="100%" position="relative">
+      <Box width="60%" height="100%" position="relative">
         {image && image.startsWith("http") && (
           <Image
             src={image.toString()}

--- a/src/interfaces/design.d.ts
+++ b/src/interfaces/design.d.ts
@@ -7,12 +7,19 @@ export interface IDesign {
   courtSize: ICourtSize;
 }
 
+export interface BadgeImageState {
+  badgeImageUrl: string | null;
+  width: number;
+  height: number;
+}
+
 export interface IDesignDetail extends IDesign {
   description: string;
   createdAt: string;
   updatedAt: string;
   isDeleted: boolean;
   image: string;
+  badgeImage: BadgeImageState;
 }
 
 export interface ITileColor {
@@ -58,5 +65,6 @@ export interface ISaveDesign {
   tileColor: ITileColor[];
   courtSize: ICourtSize;
   image: string;
+  badgeImage: BadgeImageState;
   courtType: string;
 }

--- a/src/store/reducer/badgeSlice.ts
+++ b/src/store/reducer/badgeSlice.ts
@@ -1,11 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-
-export interface BadgeImageState {
-  badgeImageUrl: string | null;
-  width: number;
-  height: number;
-}
-
+import { BadgeImageState } from "@/interfaces/design";
 export interface BadgeState {
   isBadgeUsed: boolean;
   badgeImage: BadgeImageState;
@@ -36,9 +30,12 @@ export const badgeSlice = createSlice({
         badgeImage: action.payload,
       };
     },
+    resetBadgeImage: () => {
+      return initialState;
+    },
   },
 });
 
-export const { switchBadgeUsed, setBadgeImage } = badgeSlice.actions;
+export const { switchBadgeUsed, setBadgeImage, resetBadgeImage } = badgeSlice.actions;
 
 export default badgeSlice.reducer;

--- a/src/store/reducer/courtSpecDataSlice.ts
+++ b/src/store/reducer/courtSpecDataSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "..";
+import { BadgeImageState } from "@/interfaces/design";
 
 export interface CourtSizeState {
   courtId: string;
@@ -20,6 +21,7 @@ export interface CourtSizeState {
   createdAt: string;
   updatedAt: string;
   image: string;
+  badgeImage?: BadgeImageState;
 }
 export interface CourtSpecMapper {
   [prop: string]: string;

--- a/src/utils/designMapping.ts
+++ b/src/utils/designMapping.ts
@@ -29,6 +29,7 @@ export const designCourtMapping = (item: IDesignDetail) => ({
   createdAt: item.createdAt,
   updatedAt: item.updatedAt,
   image: item.image,
+  badgeImage: item.badgeImage,
 });
 
 export const designTileMapping = (item: IDesignDetail) => ({

--- a/src/utils/generateNewTemplate.ts
+++ b/src/utils/generateNewTemplate.ts
@@ -25,6 +25,11 @@ const generateNewTemplate = (
     tileColor: tiles,
     courtSize: courtSizeData,
     image: "",
+    badgeImage: {
+      badgeImageUrl: null,
+      width: 0,
+      height: 0,
+    },
     courtType: COURT_TYPE,
   };
 


### PR DESCRIPTION
1. Save badge image to S3 via cc server when the design with badge image is saved or saved as

2. Load the badge image from the design with the badge image in the folder.
![image](https://github.com/courtcanva/cc-app/assets/81401008/fd7dbb4f-962f-4801-9cab-6f7a5263e9ae)
![image](https://github.com/courtcanva/cc-app/assets/81401008/f530f36b-59ae-493c-9a4c-2f2251527ed6)
